### PR TITLE
Development setup for skaffold

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ build
  # Docker configuration
 .dockerignore
 Dockerfile
+Dockerfile_dev
 docker-compose*.yml
 skaffold.yaml
 

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,0 +1,19 @@
+FROM node:alpine
+
+RUN apk add python2 make g++
+
+WORKDIR /workspace
+
+COPY package.json /workspace/package.json
+COPY packages /workspace/packages
+COPY .npmrc .npmrc
+COPY .yarnrc .yarnrc
+
+RUN yarn config set workspaces-experimental true
+RUN yarn install
+
+COPY . /workspace/
+
+ENV NODE_ENV=development
+
+CMD ["yarn", "start"]

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -6,8 +6,6 @@ WORKDIR /workspace
 
 COPY package.json /workspace/package.json
 COPY packages /workspace/packages
-COPY .npmrc .npmrc
-COPY .yarnrc .yarnrc
 
 RUN yarn config set workspaces-experimental true
 RUN yarn install

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ $> docker-compose up -d --force-recreate --build
 
 If your substra-backend instance use basicauth settings, you need to pass the `BACK_AUTH_USER` and `BACK_AUTH_PASSWORD` variables to your current environment for not triggering 403 responses.
 
+## Skaffold launch
+
+Launch in production mode:
+
+```bash
+$> skaffold dev --no-prune
+```
+
+Launch in development mode:
+
+```bash
+$> skaffold dev --no-prune -p dev
+```
 
 ## Substra-UI
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ If your substra-backend instance use basicauth settings, you need to pass the `B
 Launch in production mode:
 
 ```bash
-$> skaffold dev --no-prune
+$> skaffold dev
 ```
 
 Launch in development mode:
 
 ```bash
-$> skaffold dev --no-prune -p dev
+$> skaffold dev -p dev
 ```
 
 ## Substra-UI

--- a/charts/substra-frontend/Chart.yaml
+++ b/charts/substra-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-frontend
 home: https://substra.org/
-version: 1.0.0-alpha.2
+version: 1.0.0-alpha.3
 description: Main package for Substra Frontend
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-frontend/templates/deployment.yaml
+++ b/charts/substra-frontend/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
           {{- if .Values.image.pullPolicy }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- end }}
-          command: ["./node_modules/.bin/babel-node", "./build/ssr/index.js"]
           env:
             - name: REDIS_PORT
               value: {{ .Values.redis.port | quote }}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -43,3 +43,18 @@ deploy:
               - { host: substra-frontend.node-2.com, paths: ["/"] }
             annotations:
               kubernetes.io/ingress.class: nginx
+profiles:
+  - name: dev
+    patches:
+      - op: add
+        path: /build/artifacts/0/docker/dockerfile
+        value: Dockerfile_dev
+      - op: remove
+        path: /build/artifacts/0/docker/target
+      - op: add
+        path: /build/artifacts/0/sync
+        value:
+            manual:
+              - src: 'src/**/*'
+                strip: 'src/'
+                dest: /workspace/src


### PR DESCRIPTION
This PR adds a `dev` profile to skaffold enabling people to run the frontend in development mode the same way they would with `yarn start`.

In order to do so, there was  a need for a new, simplified Dockerfile : `Dockerfile_dev`.

The deployment template was running containers with its own command instead on relying on the CMD instruction from the Dockerfile. This has been removed with no impact since this specific command was the exact same as the one specified in the "standard" Dockerfile.

Nota bene: this is a first step in the direction of a full dev env using skaffold, there is still one big catch : there's no browsersync. This will have to be fixed in a later PR but it may be quite complicated as it involves opening a websocket between the container and the browser through pods, services and ingress.