### PR TITLE
Composite/Aggregate tuples

### DIFF
--- a/src/app/business/common/components/base/index.js
+++ b/src/app/business/common/components/base/index.js
@@ -10,7 +10,7 @@ import Detail from '../detail/redux';
 export const margin = 40;
 
 
-class Base extends Component {
+export class BaseComponent extends Component {
     filterUp = (o) => {
         const {
             setSearchState, selectedItem, model,
@@ -94,7 +94,7 @@ class Base extends Component {
     }
 }
 
-Base.defaultProps = {
+BaseComponent.defaultProps = {
     selected: null,
     selectedItem: [],
     item: null,
@@ -107,7 +107,7 @@ Base.defaultProps = {
     Detail,
 };
 
-Base.propTypes = {
+BaseComponent.propTypes = {
     selected: PropTypes.string,
     actions: PropTypes.shape({}).isRequired,
     model: PropTypes.string.isRequired,
@@ -128,6 +128,6 @@ Base.propTypes = {
     Detail: PropTypes.elementType,
 };
 
-const BaseWithAddNotification = withAddNotification(Base, Check);
+const BaseWithAddNotification = withAddNotification(BaseComponent, Check);
 
 export default BaseWithAddNotification;

--- a/src/app/business/common/components/detail/components/metadata.js
+++ b/src/app/business/common/components/detail/components/metadata.js
@@ -8,7 +8,7 @@ import {spacingExtraSmall, spacingSmall} from '../../../../../../../assets/css/v
 import {blueGrey} from '../../../../../../../assets/css/variables/colors';
 import CopyInput from './copyInput';
 
-const LABEL_WIDTH = '160';
+const LABEL_WIDTH = '200';
 
 export const MetadataWrapper = styled('dl')`
     display: flex;

--- a/src/app/business/common/components/list/components/metadata.js
+++ b/src/app/business/common/components/list/components/metadata.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {css} from 'emotion';
+import styled from '@emotion/styled';
 
-import {spacingNormal, spacingSmall} from '../../../../../../../assets/css/variables/spacing';
-import {blueGrey} from '../../../../../../../assets/css/variables/colors';
+import {spacingNormal, spacingSmall, spacingExtraSmall} from '../../../../../../../assets/css/variables/spacing';
+import {blueGrey, slate} from '../../../../../../../assets/css/variables/colors';
+import {fontNormal} from '../../../../../../../assets/css/variables/font';
 
 const singleMetadata = css`
     margin-right: ${spacingNormal};
@@ -39,4 +41,12 @@ export const metadata = css`
     vertical-align: top;
     margin-top: ${spacingSmall};
     color: ${blueGrey};
+`;
+
+export const MetadataTag = styled('div')`
+    display: inline-block;
+    font-size: ${fontNormal};
+    border-radius: ${spacingSmall};
+    padding: 0 ${spacingExtraSmall};
+    border: 1px solid ${slate};
 `;

--- a/src/app/business/routes/algo/api.js
+++ b/src/app/business/routes/algo/api.js
@@ -1,7 +1,23 @@
 import {fetchEntitiesFactory, fetchEntityFactory} from '../../../entities/fetchEntities';
 
-export const fetchListApi = fetchEntitiesFactory('algo');
-export const fetchItemApi = fetchEntityFactory('algo');
+const fetchStandardAlgoListApi = fetchEntitiesFactory('algo');
+const fetchCompositeAlgoListApi = fetchEntitiesFactory('composite_algo');
+
+export function fetchListApi(...args) {
+    const promises = [
+        fetchStandardAlgoListApi(...args),
+        fetchCompositeAlgoListApi(...args),
+    ];
+    return Promise.all(promises);
+}
+
+const fetchStandardAlgoApi = fetchEntityFactory('algo');
+const fetchCompositeAlgoApi = fetchEntityFactory('composite_algo');
+
+export function fetchItemApi(...args) {
+    fetchStandardAlgoApi(...args);
+    fetchCompositeAlgoApi(...args);
+}
 
 export default {
     fetchListApi,

--- a/src/app/business/routes/algo/api.js
+++ b/src/app/business/routes/algo/api.js
@@ -11,15 +11,11 @@ export function fetchListApi(...args) {
     return Promise.all(promises);
 }
 
-const fetchStandardAlgoApi = fetchEntityFactory('algo');
-const fetchCompositeAlgoApi = fetchEntityFactory('composite_algo');
-
-export function fetchItemApi(...args) {
-    fetchStandardAlgoApi(...args);
-    fetchCompositeAlgoApi(...args);
-}
+export const fetchStandardAlgoApi = fetchEntityFactory('algo');
+export const fetchCompositeAlgoApi = fetchEntityFactory('composite_algo');
 
 export default {
     fetchListApi,
-    fetchItemApi,
+    fetchStandardAlgoApi,
+    fetchCompositeAlgoApi,
 };

--- a/src/app/business/routes/algo/api.js
+++ b/src/app/business/routes/algo/api.js
@@ -2,20 +2,24 @@ import {fetchEntitiesFactory, fetchEntityFactory} from '../../../entities/fetchE
 
 const fetchStandardAlgoListApi = fetchEntitiesFactory('algo');
 const fetchCompositeAlgoListApi = fetchEntitiesFactory('composite_algo');
+const fetchAggregateAlgoListApi = fetchEntitiesFactory('aggregate_algo');
 
 export function fetchListApi(...args) {
     const promises = [
         fetchStandardAlgoListApi(...args),
         fetchCompositeAlgoListApi(...args),
+        fetchAggregateAlgoListApi(...args),
     ];
     return Promise.all(promises);
 }
 
 export const fetchStandardAlgoApi = fetchEntityFactory('algo');
 export const fetchCompositeAlgoApi = fetchEntityFactory('composite_algo');
+export const fetchAggregateAlgoApi = fetchEntityFactory('aggregate_algo');
 
 export default {
     fetchListApi,
     fetchStandardAlgoApi,
     fetchCompositeAlgoApi,
+    fetchAggregateAlgoApi,
 };

--- a/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
+++ b/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
@@ -15,7 +15,13 @@ import BrowseRelatedLink from '../../../../../common/components/detail/component
 const BrowseRelatedLinks = ({
                                 item, unselectObjective, unselectDataset, unselectModel,
                             }) => {
-    const asset = item && item.type === 'composite' ? 'composite_algo' : 'algo';
+    let asset = 'algo';
+    if (item && item.type === 'composite') {
+        asset = 'composite_algo';
+    }
+    else if (item && item.type === 'aggregate') {
+        asset = 'aggregate_algo';
+    }
     const filter = `${asset}:name:${item ? encodeURIComponent(item.name) : ''}`;
 
     return (

--- a/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
+++ b/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
@@ -15,7 +15,8 @@ import BrowseRelatedLink from '../../../../../common/components/detail/component
 const BrowseRelatedLinks = ({
                                 item, unselectObjective, unselectDataset, unselectModel,
                             }) => {
-    const filter = `algo:name:${item ? encodeURIComponent(item.name) : ''}`;
+    const asset = item && item.type === 'composite' ? 'composite_algo' : 'algo';
+    const filter = `${asset}:name:${item ? encodeURIComponent(item.name) : ''}`;
 
     return (
         <Fragment>

--- a/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
+++ b/src/app/business/routes/algo/components/detail/components/browseRelatedLinks.js
@@ -15,13 +15,7 @@ import BrowseRelatedLink from '../../../../../common/components/detail/component
 const BrowseRelatedLinks = ({
                                 item, unselectObjective, unselectDataset, unselectModel,
                             }) => {
-    let asset = 'algo';
-    if (item && item.type === 'composite') {
-        asset = 'composite_algo';
-    }
-    else if (item && item.type === 'aggregate') {
-        asset = 'aggregate_algo';
-    }
+    const asset = item && ['composite', 'aggregate'].includes(item.type) ? `${item.type}_algo` : 'algo';
     const filter = `${asset}:name:${item ? encodeURIComponent(item.name) : ''}`;
 
     return (

--- a/src/app/business/routes/algo/components/detail/components/metadata.js
+++ b/src/app/business/routes/algo/components/detail/components/metadata.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import {capitalize} from 'lodash';
+
 import BaseMetadata, {
     MetadataWrapper,
     KeyMetadata,
-    BrowseRelatedMetadata, PermissionsMetadata, OwnerMetadata,
+    BrowseRelatedMetadata, PermissionsMetadata, OwnerMetadata, SingleMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import BrowseRelatedLinks from './browseRelatedLinks';
 
@@ -10,6 +12,7 @@ import BrowseRelatedLinks from './browseRelatedLinks';
 const Metadata = ({item, addNotification, model}) => (
     <MetadataWrapper>
         <KeyMetadata item_key={item.key} addNotification={addNotification} model={model} />
+        <SingleMetadata label="Type" value={capitalize(item.type)} />
         <OwnerMetadata owner={item.owner} />
         <PermissionsMetadata permissions={item.permissions} />
         <BrowseRelatedMetadata>

--- a/src/app/business/routes/algo/components/index.js
+++ b/src/app/business/routes/algo/components/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReduxBase from '../../../common/components/base/redux';
 import Detail from './detail/redux';
+import List from './list/redux';
 
 import actions from '../actions';
 
@@ -12,6 +13,14 @@ const download = {
     text: 'Download algo',
 };
 
-const Algo = () => <AlgoBase actions={actions} model="algo" download={download} Detail={Detail} />;
+const Algo = () => (
+    <AlgoBase
+        actions={actions}
+        model="algo"
+        download={download}
+        Detail={Detail}
+        List={List}
+    />
+);
 
 export default Algo;

--- a/src/app/business/routes/algo/components/list/components/metadata.js
+++ b/src/app/business/routes/algo/components/list/components/metadata.js
@@ -1,0 +1,26 @@
+import React, {Fragment} from 'react';
+import PropTypes from 'prop-types';
+
+import {metadata, MetadataTag} from '../../../../../common/components/list/components/metadata';
+
+const Metadata = ({o}) => (
+    <Fragment>
+        {o && o.type === 'composite' && (
+            <div className={metadata}>
+                <MetadataTag>Composite</MetadataTag>
+            </div>
+        )}
+    </Fragment>
+);
+
+Metadata.propTypes = {
+    o: PropTypes.shape({
+        type: PropTypes.string,
+    }),
+};
+
+Metadata.defaultProps = {
+    o: null,
+};
+
+export default Metadata;

--- a/src/app/business/routes/algo/components/list/components/metadata.js
+++ b/src/app/business/routes/algo/components/list/components/metadata.js
@@ -10,6 +10,11 @@ const Metadata = ({o}) => (
                 <MetadataTag>Composite</MetadataTag>
             </div>
         )}
+        {o && o.type === 'aggregate' && (
+            <div className={metadata}>
+                <MetadataTag>Aggregate</MetadataTag>
+            </div>
+        )}
     </Fragment>
 );
 

--- a/src/app/business/routes/algo/components/list/components/metadata.js
+++ b/src/app/business/routes/algo/components/list/components/metadata.js
@@ -1,18 +1,14 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
+import {capitalize} from 'lodash';
 
 import {metadata, MetadataTag} from '../../../../../common/components/list/components/metadata';
 
 const Metadata = ({o}) => (
     <Fragment>
-        {o && o.type === 'composite' && (
+        {o && ['composite', 'aggregate'].includes(o.type) && (
             <div className={metadata}>
-                <MetadataTag>Composite</MetadataTag>
-            </div>
-        )}
-        {o && o.type === 'aggregate' && (
-            <div className={metadata}>
-                <MetadataTag>Aggregate</MetadataTag>
+                <MetadataTag>{capitalize(o.type)}</MetadataTag>
             </div>
         )}
     </Fragment>

--- a/src/app/business/routes/algo/components/list/index.js
+++ b/src/app/business/routes/algo/components/list/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import List from '../../../../common/components/list';
+import Metadata from './components/metadata';
+
+const AlgoList = props => (
+    <List
+        Metadata={Metadata}
+        {...props}
+    />
+);
+
+export default AlgoList;

--- a/src/app/business/routes/algo/components/list/redux.js
+++ b/src/app/business/routes/algo/components/list/redux.js
@@ -1,0 +1,39 @@
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {getItem, getSelected, getOrderedResults} from '../../../../common/selector';
+
+import {withListAnalytics} from '../../../../common/components/list/analytics';
+import List from './index';
+
+const ListWithAnalytics = withListAnalytics(List);
+
+const mapStateToProps = (state, {
+    model, filterUp, downloadFile, download, addNotification, more,
+}) => ({
+    init: state[model].list.init,
+    loading: state[model].list.loading,
+    itemLoading: state[model].item.loading,
+    itemResults: state[model].item.results,
+    results: getOrderedResults(state, model),
+    selected: getSelected(state, model),
+    order: state[model].order,
+    item: getItem(state, model),
+    location: state.location,
+    model,
+    download,
+    filterUp,
+    downloadFile,
+    addNotification,
+    more,
+});
+
+const mapDispatchToProps = (dispatch, {actions}) => bindActionCreators({
+    fetchList: actions.list.request,
+    setSelected: actions.list.selected,
+    setOrder: actions.order.set,
+    fetchItem: actions.item.request,
+}, dispatch);
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(ListWithAnalytics);

--- a/src/app/business/routes/algo/sagas/index.js
+++ b/src/app/business/routes/algo/sagas/index.js
@@ -8,7 +8,7 @@ import {saveAs} from 'file-saver';
 import cookie from 'cookie-parse';
 
 import actions, {actionTypes} from '../actions';
-import {fetchListApi, fetchItemApi} from '../api';
+import {fetchListApi, fetchStandardAlgoApi, fetchCompositeAlgoApi} from '../api';
 import {
 fetchPersistentSaga, fetchItemSaga, setOrderSaga,
 } from '../../../common/sagas';
@@ -92,6 +92,7 @@ function* fetchItem({payload}) {
         yield put(signOut.success());
     }
     else {
+        const fetchItemApi = payload.type === 'composite' ? fetchCompositeAlgoApi : fetchStandardAlgoApi;
         yield call(fetchItemSaga(actions, fetchItemApi), {
             payload: {
                 id: payload.key,

--- a/src/app/business/routes/algo/sagas/index.js
+++ b/src/app/business/routes/algo/sagas/index.js
@@ -10,7 +10,7 @@ import cookie from 'cookie-parse';
 import actions, {actionTypes} from '../actions';
 import {fetchListApi, fetchStandardAlgoApi, fetchCompositeAlgoApi} from '../api';
 import {
-fetchPersistentSaga, fetchItemSaga, setOrderSaga,
+fetchItemSaga, setOrderSaga,
 } from '../../../common/sagas';
 import {fetchRaw} from '../../../../entities/fetchEntities';
 import {getItem} from '../../../common/selector';
@@ -40,6 +40,33 @@ const fetchListSaga = (actions, fetchListApi) => function* fetchList({payload}) 
             withAlgoType(listCompositeAlgos, 'composite'),
         );
         yield put(actions.list.success(list));
+    }
+
+    return list;
+};
+
+
+const fetchPersistentSaga = (actions, fetchListApi) => function* fetchList({payload}) {
+    const [resStandardAlgos, resCompositeAlgos] = yield call(fetchListApi, payload);
+    const {error: errorStandardAlgos, status: statusStandardAlgos, list: listStandardAlgos} = resStandardAlgos;
+    const {error: errorCompositeAlgos, status: statusCompositeAlgos, list: listCompositeAlgos} = resCompositeAlgos;
+
+    let list;
+
+    if (errorStandardAlgos) {
+        console.error(errorStandardAlgos, statusStandardAlgos);
+        yield put(actions.persistent.failure(errorStandardAlgos));
+    }
+    else if (errorCompositeAlgos) {
+        console.error(errorCompositeAlgos, statusCompositeAlgos);
+        yield put(actions.persistent.failure(errorCompositeAlgos));
+    }
+    else {
+        list = [].concat(
+            withAlgoType(listStandardAlgos, 'standard'),
+            withAlgoType(listCompositeAlgos, 'composite'),
+        );
+        yield put(actions.persistent.success(list));
     }
 
     return list;

--- a/src/app/business/routes/algo/sagas/index.js
+++ b/src/app/business/routes/algo/sagas/index.js
@@ -35,17 +35,19 @@ const fetchListSaga = (actions, fetchListApi) => function* fetchList({payload}) 
 
     let list;
 
-    if (errorStandardAlgos) {
-        console.error(errorStandardAlgos, statusStandardAlgos);
-        yield put(actions.list.failure(errorStandardAlgos));
-    }
-    else if (errorCompositeAlgos) {
-        console.error(errorCompositeAlgos, statusCompositeAlgos);
-        yield put(actions.list.failure(errorCompositeAlgos));
-    }
-    else if (errorAggregateAlgos) {
-        console.error(errorAggregateAlgos, statusAggregateAlgos);
-        yield put(actions.list.failure(errorAggregateAlgos));
+    if (errorStandardAlgos || errorCompositeAlgos || errorAggregateAlgos) {
+        if (errorStandardAlgos) {
+            console.error(errorStandardAlgos, statusStandardAlgos);
+            yield put(actions.list.failure(errorStandardAlgos));
+        }
+        if (errorCompositeAlgos) {
+            console.error(errorCompositeAlgos, statusCompositeAlgos);
+            yield put(actions.list.failure(errorCompositeAlgos));
+        }
+        if (errorAggregateAlgos) {
+            console.error(errorAggregateAlgos, statusAggregateAlgos);
+            yield put(actions.list.failure(errorAggregateAlgos));
+        }
     }
     else {
         list = [].concat(
@@ -68,17 +70,19 @@ const fetchPersistentSaga = (actions, fetchListApi) => function* fetchList({payl
 
     let list;
 
-    if (errorStandardAlgos) {
-        console.error(errorStandardAlgos, statusStandardAlgos);
-        yield put(actions.persistent.failure(errorStandardAlgos));
-    }
-    else if (errorCompositeAlgos) {
-        console.error(errorCompositeAlgos, statusCompositeAlgos);
-        yield put(actions.persistent.failure(errorCompositeAlgos));
-    }
-    else if (errorAggregateAlgos) {
-        console.error(errorAggregateAlgos, statusAggregateAlgos);
-        yield put(actions.persistent.failure(errorAggregateAlgos));
+    if (errorStandardAlgos || errorCompositeAlgos || errorAggregateAlgos) {
+        if (errorStandardAlgos) {
+            console.error(errorStandardAlgos, statusStandardAlgos);
+            yield put(actions.persistent.failure(errorStandardAlgos));
+        }
+        if (errorCompositeAlgos) {
+            console.error(errorCompositeAlgos, statusCompositeAlgos);
+            yield put(actions.persistent.failure(errorCompositeAlgos));
+        }
+        if (errorAggregateAlgos) {
+            console.error(errorAggregateAlgos, statusAggregateAlgos);
+            yield put(actions.persistent.failure(errorAggregateAlgos));
+        }
     }
     else {
         list = [].concat(

--- a/src/app/business/routes/model/bundleByTag.js
+++ b/src/app/business/routes/model/bundleByTag.js
@@ -136,11 +136,19 @@ const bundleByTag = (groups, modelsDetailsByKey) => groups.map((models) => {
     return Object.keys(byTags).reduce((groupedModels, tag) => {
         const tagModels = byTags[tag];
 
-        if (tag === 'undefined' || tag === '') {
+        if (tag === 'null' || tag === 'undefined' || tag === '') {
             // these models have no tag, they shouldn't be bundled
             return [
                 ...groupedModels,
-                ...tagModels,
+                ...tagModels.map(model => ({
+                    traintuple: {
+                        ...(model.traintuple || model.compositeTraintuple),
+                        type: model.compositeTraintuple ? 'composite' : 'standard',
+                    },
+                    testtuple: {
+                        ...model.testtuple,
+                    },
+                })),
             ];
         }
 

--- a/src/app/business/routes/model/bundleByTag.js
+++ b/src/app/business/routes/model/bundleByTag.js
@@ -140,15 +140,7 @@ const bundleByTag = (groups, modelsDetailsByKey) => groups.map((models) => {
             // these models have no tag, they shouldn't be bundled
             return [
                 ...groupedModels,
-                ...tagModels.map(model => ({
-                    traintuple: {
-                        ...(model.traintuple || model.compositeTraintuple),
-                        type: model.compositeTraintuple ? 'composite' : 'standard',
-                    },
-                    testtuple: {
-                        ...model.testtuple,
-                    },
-                })),
+                ...tagModels,
             ];
         }
 

--- a/src/app/business/routes/model/components/base/index.js
+++ b/src/app/business/routes/model/components/base/index.js
@@ -1,8 +1,10 @@
 import uuidv4 from 'uuid/v4';
-import Base from '../../../../common/components/base';
+import {Check, withAddNotification} from '@substrafoundation/substra-ui';
+
+import {BaseComponent} from '../../../../common/components/base';
 
 
-class ModelBase extends Base {
+class ModelBase extends BaseComponent {
     filterUp = (o) => {
         const {
             setSearchState, selectedItem, model,
@@ -10,15 +12,9 @@ class ModelBase extends Base {
 
         const newSelectedItem = [
             ...selectedItem,
-            // This is the -OR- case
-            // ...(selectedItem.length && !last(selectedItem).isLogic ? [{
-            //     parent: '-OR-',
-            //     isLogic: true,
-            //     uuid: uuidv4(),
-            // }] : []),
             {
                 parent: model,
-                child: `hash:${o}`,
+                child: `key:${o}`,
                 isLogic: false,
                 uuid: uuidv4(),
             }];
@@ -33,4 +29,6 @@ class ModelBase extends Base {
     };
 }
 
-export default ModelBase;
+const ModelBaseWithAddNotification = withAddNotification(ModelBase, Check);
+
+export default ModelBaseWithAddNotification;

--- a/src/app/business/routes/model/components/detail/components/actions.js
+++ b/src/app/business/routes/model/components/detail/components/actions.js
@@ -6,7 +6,7 @@ import Actions, {
 
 const ModelActions = ({filterUp}) => (
     <div className={actions}>
-        <FilterAction filterUp={filterUp} />
+        {/* <FilterAction filterUp={filterUp} /> */}
     </div>
 );
 

--- a/src/app/business/routes/model/components/detail/components/actions.js
+++ b/src/app/business/routes/model/components/detail/components/actions.js
@@ -6,7 +6,7 @@ import Actions, {
 
 const ModelActions = ({filterUp}) => (
     <div className={actions}>
-        {/* <FilterAction filterUp={filterUp} /> */}
+        <FilterAction filterUp={filterUp} />
     </div>
 );
 

--- a/src/app/business/routes/model/components/detail/components/browseRelatedLinks.js
+++ b/src/app/business/routes/model/components/detail/components/browseRelatedLinks.js
@@ -16,13 +16,16 @@ const BrowseRelatedLinks = ({
                             }) => {
     const modelHash = item && item.traintuple && item.traintuple.outModel && item.traintuple.outModel.hash;
     let algoFilter,
+        hasPrefix = false,
         objectiveFilter,
         datasetFilter;
     if (modelHash) {
         algoFilter = objectiveFilter = datasetFilter = `model:hash:${modelHash}`;
     }
     else {
-        algoFilter = `${item && item.traintuple && item.traintuple.type === 'composite' ? 'composite_algo' : 'algo'}:name:${item && item.traintuple && item.traintuple.algo ? encodeURIComponent(item.traintuple.algo.name) : ''}`;
+        hasPrefix = item && item.traintuple && ['composite', 'aggregate'].includes(item.traintuple.type);
+        const algoPrefix = hasPrefix ? `${item.traintuple.type}_algo` : 'algo';
+        algoFilter = `${algoPrefix}:name:${item && item.traintuple && item.traintuple.algo ? encodeURIComponent(item.traintuple.algo.name) : ''}`;
         objectiveFilter = item && item.traintuple && item.traintuple.objective && `objective:key:${item.traintuple.objective.hash}`;
         datasetFilter = [
             item.traintuple,
@@ -41,7 +44,12 @@ const BrowseRelatedLinks = ({
 
     return (
         <Fragment>
-            <BrowseRelatedLink model="algo" label={item && item.traintuple && item.traintuple.type === 'composite' ? 'composite algorithm' : 'algorithm'} filter={algoFilter} unselect={unselectAlgo} />
+            <BrowseRelatedLink
+                model="algo"
+                label={hasPrefix ? `${item.traintuple.type} algorithm` : 'algorithm'}
+                filter={algoFilter}
+                unselect={unselectAlgo}
+            />
             {objectiveFilter && <BrowseRelatedLink model="objective" label="objective" filter={objectiveFilter} unselect={unselectObjective} />}
             {datasetFilter && <BrowseRelatedLink model="dataset" label="dataset(s)" filter={datasetFilter} unselect={unselectDataset} />}
         </Fragment>

--- a/src/app/business/routes/model/components/detail/components/browseRelatedLinks.js
+++ b/src/app/business/routes/model/components/detail/components/browseRelatedLinks.js
@@ -22,7 +22,7 @@ const BrowseRelatedLinks = ({
         algoFilter = objectiveFilter = datasetFilter = `model:hash:${modelHash}`;
     }
     else {
-        algoFilter = `algo:name:${item && item.traintuple && item.traintuple.algo ? encodeURIComponent(item.traintuple.algo.name) : ''}`;
+        algoFilter = `${item && item.traintuple && item.traintuple.type === 'composite' ? 'composite_algo' : 'algo'}:name:${item && item.traintuple && item.traintuple.algo ? encodeURIComponent(item.traintuple.algo.name) : ''}`;
         objectiveFilter = item && item.traintuple && item.traintuple.objective && `objective:key:${item.traintuple.objective.hash}`;
         datasetFilter = [
             item.traintuple,
@@ -41,7 +41,7 @@ const BrowseRelatedLinks = ({
 
     return (
         <Fragment>
-            <BrowseRelatedLink model="algo" label="algorithm" filter={algoFilter} unselect={unselectAlgo} />
+            <BrowseRelatedLink model="algo" label={item && item.traintuple && item.traintuple.type === 'composite' ? 'composite algorithm' : 'algorithm'} filter={algoFilter} unselect={unselectAlgo} />
             {objectiveFilter && <BrowseRelatedLink model="objective" label="objective" filter={objectiveFilter} unselect={unselectObjective} />}
             {datasetFilter && <BrowseRelatedLink model="dataset" label="dataset(s)" filter={datasetFilter} unselect={unselectDataset} />}
         </Fragment>

--- a/src/app/business/routes/model/components/detail/components/metadata.js
+++ b/src/app/business/routes/model/components/detail/components/metadata.js
@@ -58,6 +58,12 @@ class Metadata extends Component {
                         <KeyMetadata addNotification={this.addNotification} assetName="trunk model" assetKey={item.traintuple.outTrunkModel ? item.traintuple.outTrunkModel.outModel.hash : 'N/A'} />
                     </React.Fragment>
                 )}
+                {type === 'aggregate' && (
+                    <React.Fragment>
+                        <KeyMetadata addNotification={this.addNotification} assetName="aggregatetuple" assetKey={item.traintuple.key} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="model" assetKey={item.traintuple.outModel ? item.traintuple.outModel.hash : 'N/A'} />
+                    </React.Fragment>
+                )}
                 <SingleMetadata label="Status">
                     {capitalize(item.traintuple.status)}
                     <InlinePulseLoader loading={['waiting', 'todo', 'doing'].includes(item.traintuple.status)} />
@@ -73,7 +79,7 @@ class Metadata extends Component {
                     )}
                 </SingleMetadata>
                 <SingleMetadata label="Creator" value={item.traintuple.creator} />
-                <SingleMetadata label="Worker" value={item.traintuple.dataset.worker} />
+                <SingleMetadata label="Worker" value={type === 'aggregate' ? item.traintuple.worker : item.traintuple.dataset.worker} />
                 <PermissionsMetadata permissions={item.traintuple.permissions} />
                 <BrowseRelatedMetadata>
                     <BrowseRelatedLinks item={item} />

--- a/src/app/business/routes/model/components/detail/components/metadata.js
+++ b/src/app/business/routes/model/components/detail/components/metadata.js
@@ -1,4 +1,5 @@
 import React, {Component, Fragment} from 'react';
+import PropTypes from 'prop-types';
 import {capitalize} from 'lodash';
 
 import BaseMetadata, {
@@ -14,6 +15,25 @@ import BrowseRelatedLinks from './browseRelatedLinks';
 import InlinePulseLoader from '../../inlinePulseLoader';
 
 
+const KeyMetadata = ({addNotification, assetName, assetKey}) => (
+    <SingleMetadata
+        label={`${capitalize(assetName)} key`}
+        labelClassName={keyLabelClassName}
+        valueClassName={keyValueClassName}
+    >
+        <CopyInput
+            value={assetKey}
+            addNotification={addNotification(assetKey, `${capitalize(assetName)}'s key successfully copied to clipboard!`)}
+        />
+    </SingleMetadata>
+);
+
+KeyMetadata.propTypes = {
+    addNotification: PropTypes.func.isRequired,
+    assetName: PropTypes.string.isRequired,
+    assetKey: PropTypes.string.isRequired,
+};
+
 class Metadata extends Component {
     addNotification = (value, message) => () => {
         const {addNotification} = this.props;
@@ -22,32 +42,21 @@ class Metadata extends Component {
 
     render() {
         const {item} = this.props;
+        const {traintuple: {type}} = item;
         return (
             <MetadataWrapper>
-                <SingleMetadata
-                    label="Traintuple key"
-                    labelClassName={keyLabelClassName}
-                    valueClassName={keyValueClassName}
-                >
-                    <CopyInput
-                        value={item.traintuple.key}
-                        addNotification={this.addNotification(item.traintuple.key, 'Traintuple\'s key successfully copied to clipboard!')}
-                    />
-                </SingleMetadata>
-                {item.traintuple.outModel && (
-                    <SingleMetadata
-                        label="Model key"
-                        labelClassName={keyLabelClassName}
-                        valueClassName={keyValueClassName}
-                    >
-                        <CopyInput
-                            value={item.traintuple.outModel.hash}
-                            addNotification={this.addNotification(item.traintuple.outModel.hash, 'Model\'s key successfully copied to clipboard!')}
-                        />
-                    </SingleMetadata>
+                {type === 'standard' && (
+                    <React.Fragment>
+                        <KeyMetadata addNotification={this.addNotification} assetName="traintuple" assetKey={item.traintuple.key} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="model" assetKey={item.traintuple.outModel ? item.traintuple.outModel.hash : 'N/A'} />
+                    </React.Fragment>
                 )}
-                {!item.traintuple.outModel && (
-                    <SingleMetadata label="Model key" value="N/A" />
+                {type === 'composite' && (
+                    <React.Fragment>
+                        <KeyMetadata addNotification={this.addNotification} assetName="composite traintuple" assetKey={item.traintuple.key} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="head model" assetKey={item.traintuple.outHeadModel ? item.traintuple.outHeadModel.outModel.hash : 'N/A'} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="trunk model" assetKey={item.traintuple.outTrunkModel ? item.traintuple.outTrunkModel.outModel.hash : 'N/A'} />
+                    </React.Fragment>
                 )}
                 <SingleMetadata label="Status">
                     {capitalize(item.traintuple.status)}

--- a/src/app/business/routes/model/components/detail/components/tabs/index.js
+++ b/src/app/business/routes/model/components/detail/components/tabs/index.js
@@ -34,13 +34,24 @@ class ModelTabs extends Component {
     render() {
         const {item, addNotification} = this.props;
         const {tabIndex} = this.state;
-        const isComposite = item && item.traintuple && item.traintuple.type === 'composite';
 
         // do not display the "type" key in the traintuple that's been inserted for the fronten's internal use
         const cleanTraintuple = item && item.traintuple && {...item.traintuple};
         if (cleanTraintuple) {
             delete cleanTraintuple.type;
         }
+
+        const tupleType = item && item.traintuple && item.traintuple.type;
+        const tupleFilename = {
+            standard: 'traintuple.json',
+            composite: 'composite_traintuple.json',
+            aggregate: 'aggregatetuple.json',
+        };
+        const tupleTabTitle = {
+            standard: 'Traintuple/Model',
+            composite: 'Composite traintuple/Head model/Trunk model',
+            aggregate: 'Aggregatetuple/Model',
+        };
 
         return (
             <Fragment>
@@ -57,11 +68,11 @@ class ModelTabs extends Component {
                     onSelect={this.setTabIndex}
                 >
                     <TabList>
-                        <Tab>{isComposite ? 'Composite traintuple / Head model / Trunk model' : 'Traintuple/Model'}</Tab>
+                        <Tab>{tupleTabTitle[tupleType]}</Tab>
                         <Tab>Testtuple</Tab>
                     </TabList>
                     <TabPanel>
-                        {item && item.traintuple && item.traintuple.status === 'done' && (
+                        {['standard', 'composite'].includes(tupleType) && item && item.traintuple && item.traintuple.status === 'done' && (
                         <p>
                             {'Model successfully trained with a score of '}
                             <b>{item.traintuple.dataset.perf.toFixed(SCORE_PRECISION)}</b>
@@ -71,7 +82,7 @@ class ModelTabs extends Component {
                         </p>
                     )}
                         <CodeSample
-                            filename={isComposite ? 'composite_traintuple.json' : 'traintuple.json'}
+                            filename={tupleFilename[tupleType]}
                             language="json"
                             codeString={JSON.stringify(cleanTraintuple, null, 2)}
                         />

--- a/src/app/business/routes/model/components/detail/components/tabs/index.js
+++ b/src/app/business/routes/model/components/detail/components/tabs/index.js
@@ -34,6 +34,13 @@ class ModelTabs extends Component {
     render() {
         const {item, addNotification} = this.props;
         const {tabIndex} = this.state;
+        const isComposite = item && item.traintuple && item.traintuple.type === 'composite';
+
+        // do not display the "type" key in the traintuple that's been inserted for the fronten's internal use
+        const cleanTraintuple = item && item.traintuple && {...item.traintuple};
+        if (cleanTraintuple) {
+            delete cleanTraintuple.type;
+        }
 
         return (
             <Fragment>
@@ -50,7 +57,7 @@ class ModelTabs extends Component {
                     onSelect={this.setTabIndex}
                 >
                     <TabList>
-                        <Tab>Traintuple/Model</Tab>
+                        <Tab>{isComposite ? 'Composite traintuple / Head model / Trunk model' : 'Traintuple/Model'}</Tab>
                         <Tab>Testtuple</Tab>
                     </TabList>
                     <TabPanel>
@@ -64,9 +71,9 @@ class ModelTabs extends Component {
                         </p>
                     )}
                         <CodeSample
-                            filename="traintuple.json"
+                            filename={isComposite ? 'composite_traintuple.json' : 'traintuple.json'}
                             language="json"
-                            codeString={JSON.stringify(item.traintuple, null, 2)}
+                            codeString={JSON.stringify(cleanTraintuple, null, 2)}
                         />
                     </TabPanel>
                     <TabPanel>

--- a/src/app/business/routes/model/components/detail/components/tabs/index.js
+++ b/src/app/business/routes/model/components/detail/components/tabs/index.js
@@ -17,6 +17,17 @@ import {
     AlertWrapper, AlertTitle, AlertInlineButton,
 } from '../../../../../../common/components/alert';
 
+const tupleFilename = {
+    standard: 'traintuple.json',
+    composite: 'composite_traintuple.json',
+    aggregate: 'aggregatetuple.json',
+};
+
+const tupleTabTitle = {
+    standard: 'Traintuple/Model',
+    composite: 'Composite traintuple/Head model/Trunk model',
+    aggregate: 'Aggregatetuple/Model',
+};
 
 class ModelTabs extends Component {
     state = {
@@ -42,16 +53,6 @@ class ModelTabs extends Component {
         }
 
         const tupleType = item && item.traintuple && item.traintuple.type;
-        const tupleFilename = {
-            standard: 'traintuple.json',
-            composite: 'composite_traintuple.json',
-            aggregate: 'aggregatetuple.json',
-        };
-        const tupleTabTitle = {
-            standard: 'Traintuple/Model',
-            composite: 'Composite traintuple/Head model/Trunk model',
-            aggregate: 'Aggregatetuple/Model',
-        };
 
         return (
             <Fragment>

--- a/src/app/business/routes/model/components/detail/index.js
+++ b/src/app/business/routes/model/components/detail/index.js
@@ -14,8 +14,8 @@ class ModelDetail extends Detail {
         e.stopPropagation();
 
         const {item, filterUp, logFilterFromDetail} = this.props;
-        filterUp(item.traintuple.outModel.hash);
-        logFilterFromDetail(item.traintuple.outModel.hash);
+        filterUp(item.traintuple.key);
+        logFilterFromDetail(item.traintuple.key);
     };
 }
 

--- a/src/app/business/routes/model/components/list/components/actions.js
+++ b/src/app/business/routes/model/components/list/components/actions.js
@@ -9,10 +9,10 @@ class SingleModelActions extends BaseActions {
         e.preventDefault();
         e.stopPropagation();
 
-        const {filterUp, logFilterFromList, item: {traintuple: {outModel: {hash}}}} = this.props;
+        const {filterUp, logFilterFromList, item: {traintuple: {key}}} = this.props;
 
-        filterUp(hash);
-        logFilterFromList(hash);
+        filterUp(key);
+        logFilterFromList(key);
 
         this.togglePopover();
     };

--- a/src/app/business/routes/model/components/list/components/actions.js
+++ b/src/app/business/routes/model/components/list/components/actions.js
@@ -16,6 +16,17 @@ class SingleModelActions extends BaseActions {
 
         this.togglePopover();
     };
+
+    addNotification = (value, message) => (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const {addNotification, logCopyFromList} = this.props;
+
+        addNotification(value, message);
+        logCopyFromList(value);
+        this.togglePopover();
+    };
 }
 
 const Actions = ({item, ...props}) => (!item.tag && (

--- a/src/app/business/routes/model/components/list/components/metadata.js
+++ b/src/app/business/routes/model/components/list/components/metadata.js
@@ -4,11 +4,10 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {capitalize} from 'lodash';
 
-import {metadata, SingleMetadata} from '../../../../../common/components/list/components/metadata';
-import {iceBlue, slate} from '../../../../../../../../assets/css/variables/colors';
+import {metadata, SingleMetadata, MetadataTag} from '../../../../../common/components/list/components/metadata';
+import {iceBlue} from '../../../../../../../../assets/css/variables/colors';
 import {spacingExtraSmall, spacingNormal, spacingSmall} from '../../../../../../../../assets/css/variables/spacing';
 import InlinePulseLoader from '../../inlinePulseLoader';
-import {fontNormal} from '../../../../../../../../assets/css/variables/font';
 
 const ScoreWrapper = styled('div')`
     background-color: ${iceBlue};
@@ -16,13 +15,6 @@ const ScoreWrapper = styled('div')`
     margin: ${spacingExtraSmall} -${spacingNormal} -${spacingSmall} -${spacingNormal};
 `;
 
-const Tag = styled('div')`
-    display: inline-block;
-    font-size: ${fontNormal};
-    border-radius: ${spacingSmall};
-    padding: 0 ${spacingExtraSmall};
-    border: 1px solid ${slate};
-`;
 
 const ScoreMetadata = ({label, testtuple}) => (
     <SingleMetadata label={label}>
@@ -51,7 +43,7 @@ const Metadata = ({o}) => (
     <Fragment>
         {o && o.tag && (
             <div className={metadata}>
-                <Tag>Model bundle</Tag>
+                <MetadataTag>Model bundle</MetadataTag>
             </div>
         )}
         <div className={metadata}>

--- a/src/app/business/routes/model/components/list/components/metadata.js
+++ b/src/app/business/routes/model/components/list/components/metadata.js
@@ -40,7 +40,7 @@ ScoreMetadata.defaultProps = {
 };
 
 const Metadata = ({o}) => {
-    const hasTags = o && (o.tag || (o.traintuple && o.traintuple.type === 'composite'));
+    const hasTags = o && (o.tag || o.traintuple && ['composite', 'aggregate'].includes(o.traintuple.type));
 
     return (
         <Fragment>
@@ -48,6 +48,7 @@ const Metadata = ({o}) => {
                 <div className={metadata}>
                     {o && o.tag && <MetadataTag>Model bundle</MetadataTag>}
                     {o && o.traintuple && o.traintuple.type === 'composite' && <MetadataTag>Composite</MetadataTag>}
+                    {o && o.traintuple && o.traintuple.type === 'aggregate' && <MetadataTag>Aggregate</MetadataTag>}
                 </div>
             )}
             <div className={metadata}>

--- a/src/app/business/routes/model/components/list/components/metadata.js
+++ b/src/app/business/routes/model/components/list/components/metadata.js
@@ -39,35 +39,40 @@ ScoreMetadata.defaultProps = {
     testtuple: null,
 };
 
-const Metadata = ({o}) => (
-    <Fragment>
-        {o && o.tag && (
+const Metadata = ({o}) => {
+    const hasTags = o && (o.tag || (o.traintuple && o.traintuple.type === 'composite'));
+
+    return (
+        <Fragment>
+            {hasTags && (
+                <div className={metadata}>
+                    {o && o.tag && <MetadataTag>Model bundle</MetadataTag>}
+                    {o && o.traintuple && o.traintuple.type === 'composite' && <MetadataTag>Composite</MetadataTag>}
+                </div>
+            )}
             <div className={metadata}>
-                <MetadataTag>Model bundle</MetadataTag>
-            </div>
-        )}
-        <div className={metadata}>
-            <SingleMetadata label="Status">
-                {capitalize(o.traintuple.status)}
-                <InlinePulseLoader loading={['waiting', 'todo', 'doing'].includes(o.traintuple.status)} />
-            </SingleMetadata>
-            {o && o.tag && o.nonCertifiedTesttuple && (
-                <ScoreMetadata
-                    label="Validation score"
-                    testtuple={o.nonCertifiedTesttuple}
-                />
-            )}
-            {o && o.testtuple && (
-                <ScoreWrapper>
+                <SingleMetadata label="Status">
+                    {capitalize(o.traintuple.status)}
+                    <InlinePulseLoader loading={['waiting', 'todo', 'doing'].includes(o.traintuple.status)} />
+                </SingleMetadata>
+                {o && o.tag && o.nonCertifiedTesttuple && (
                     <ScoreMetadata
-                        label="Score"
-                        testtuple={o.testtuple}
+                        label="Validation score"
+                        testtuple={o.nonCertifiedTesttuple}
                     />
-                </ScoreWrapper>
-            )}
-        </div>
-    </Fragment>
-);
+                )}
+                {o && o.testtuple && (
+                    <ScoreWrapper>
+                        <ScoreMetadata
+                            label="Score"
+                            testtuple={o.testtuple}
+                        />
+                    </ScoreWrapper>
+                )}
+            </div>
+        </Fragment>
+    );
+};
 
 Metadata.propTypes = {
     o: PropTypes.shape({

--- a/src/app/business/routes/model/components/list/components/metadata.js
+++ b/src/app/business/routes/model/components/list/components/metadata.js
@@ -47,8 +47,11 @@ const Metadata = ({o}) => {
             {hasTags && (
                 <div className={metadata}>
                     {o && o.tag && <MetadataTag>Model bundle</MetadataTag>}
-                    {o && o.traintuple && o.traintuple.type === 'composite' && <MetadataTag>Composite</MetadataTag>}
-                    {o && o.traintuple && o.traintuple.type === 'aggregate' && <MetadataTag>Aggregate</MetadataTag>}
+                    {o && o.traintuple && ['composite', 'aggregate'].includes(o.traintuple.type) && (
+                        <MetadataTag>
+                            {capitalize(o.traintuple.type)}
+                        </MetadataTag>
+                    )}
                 </div>
             )}
             <div className={metadata}>

--- a/src/app/business/routes/model/components/list/components/popoverItems.js
+++ b/src/app/business/routes/model/components/list/components/popoverItems.js
@@ -51,7 +51,20 @@ const CompositeModelPopoverItems = ({item, filterUp, addNotification}) => {
     );
 };
 
-StandardModelPopoverItems.propTypes = CompositeModelPopoverItems.propTypes = {
+const AggregateModelPopoverItems = ({item, filterUp, addNotification}) => {
+    const modelKey = deepGet('traintuple.outModel.hash')(item);
+    const traintupleKey = deepGet('traintuple.key')(item);
+
+    return (
+        <PopList>
+            <FilterUpPopItem filterUp={filterUp} />
+            {modelKey && <CopyPopItem addNotification={addNotification} assetKey={modelKey} assetName="model" />}
+            <CopyPopItem addNotification={addNotification} assetKey={traintupleKey} assetName="aggregatetuple" />
+        </PopList>
+    );
+};
+
+StandardModelPopoverItems.propTypes = CompositeModelPopoverItems.propTypes = AggregateModelPopoverItems.propTypes = {
     item: PropTypes.shape().isRequired,
     filterUp: PropTypes.func.isRequired,
     addNotification: PropTypes.func.isRequired,
@@ -65,6 +78,7 @@ const ModelPopoverItems = (props) => {
         <React.Fragment>
             {type === 'standard' && <StandardModelPopoverItems {...props} />}
             {type === 'composite' && <CompositeModelPopoverItems {...props} />}
+            {type === 'aggregate' && <AggregateModelPopoverItems {...props} />}
         </React.Fragment>
     );
 };

--- a/src/app/business/routes/model/components/list/components/popoverItems.js
+++ b/src/app/business/routes/model/components/list/components/popoverItems.js
@@ -1,19 +1,77 @@
 import React from 'react';
-import PopoverItems, {
-PopList, FilterUpPopItem, CopyPopItem,
+import PropTypes from 'prop-types';
+import {capitalize} from 'lodash';
+import {
+PopList, FilterUpPopItem, PopItem, Action,
 } from '../../../../../common/components/list/components/popoverItems';
+import {deepGet} from '../../../../../../utils/selector';
 
-
-const ModelPopoverItems = ({
-model, filterUp, addNotification,
-}) => (
-    <PopList>
-        <FilterUpPopItem filterUp={filterUp} />
-        <CopyPopItem model={model} addNotification={addNotification} />
-    </PopList>
+const CopyPopItem = ({addNotification, assetName, assetKey}) => (
+    <PopItem>
+        <Action onClick={addNotification(assetKey, `${capitalize(assetName)}'s key successfully copied to clipboard!`)}>
+            {`Copy ${assetName}'s key to clipboard`}
+        </Action>
+    </PopItem>
 );
 
-ModelPopoverItems.propTypes = PopoverItems.propTypes;
-ModelPopoverItems.defaultProps = PopoverItems.defaultProps;
+CopyPopItem.propTypes = {
+    addNotification: PropTypes.func.isRequired,
+    assetName: PropTypes.string.isRequired,
+    assetKey: PropTypes.string.isRequired,
+};
+
+
+const StandardModelPopoverItems = ({item, filterUp, addNotification}) => {
+    const modelKey = deepGet('traintuple.outModel.hash')(item);
+    const traintupleKey = deepGet('traintuple.key')(item);
+    return (
+        <React.Fragment>
+            <PopList>
+                {/* <FilterUpPopItem filterUp={filterUp} modelKey={modelKey} /> */}
+                {modelKey && <CopyPopItem addNotification={addNotification} assetKey={modelKey} assetName="model" />}
+                <CopyPopItem addNotification={addNotification} assetKey={traintupleKey} assetName="traintuple" />
+            </PopList>
+        </React.Fragment>
+    );
+};
+
+
+const CompositeModelPopoverItems = ({item, filterUp, addNotification}) => {
+    const headModelKey = deepGet('traintuple.outHeadModel.outModel.hash')(item);
+    const trunkModelKey = deepGet('traintuple.outTrunkModel.outModel.hash')(item);
+    const traintupleKey = deepGet('traintuple.key')(item);
+
+    return (
+        <PopList>
+            {/* <FilterUpPopItem filterUp={filterUp} /> */}
+            <CopyPopItem addNotification={addNotification} assetKey={traintupleKey} assetName="composite traintuple" />
+            {headModelKey && <CopyPopItem addNotification={addNotification} assetKey={headModelKey} assetName="head model" />}
+            {trunkModelKey && <CopyPopItem addNotification={addNotification} assetKey={trunkModelKey} assetName="trunk model" />}
+        </PopList>
+    );
+};
+
+StandardModelPopoverItems.propTypes = CompositeModelPopoverItems.propTypes = {
+    item: PropTypes.shape().isRequired,
+    filterUp: PropTypes.func.isRequired,
+    addNotification: PropTypes.func.isRequired,
+};
+
+const ModelPopoverItems = (props) => {
+    const {item} = props;
+    const type = item && item.traintuple && item.traintuple.type;
+
+    return (
+        <React.Fragment>
+            {type === 'standard' && <StandardModelPopoverItems {...props} />}
+            {type === 'composite' && <CompositeModelPopoverItems {...props} />}
+        </React.Fragment>
+    );
+};
+
+ModelPopoverItems.propTypes = {
+    item: PropTypes.shape().isRequired,
+};
+
 
 export default ModelPopoverItems;

--- a/src/app/business/routes/model/components/list/components/popoverItems.js
+++ b/src/app/business/routes/model/components/list/components/popoverItems.js
@@ -27,7 +27,7 @@ const StandardModelPopoverItems = ({item, filterUp, addNotification}) => {
     return (
         <React.Fragment>
             <PopList>
-                {/* <FilterUpPopItem filterUp={filterUp} modelKey={modelKey} /> */}
+                <FilterUpPopItem filterUp={filterUp} />
                 {modelKey && <CopyPopItem addNotification={addNotification} assetKey={modelKey} assetName="model" />}
                 <CopyPopItem addNotification={addNotification} assetKey={traintupleKey} assetName="traintuple" />
             </PopList>
@@ -43,7 +43,7 @@ const CompositeModelPopoverItems = ({item, filterUp, addNotification}) => {
 
     return (
         <PopList>
-            {/* <FilterUpPopItem filterUp={filterUp} /> */}
+            <FilterUpPopItem filterUp={filterUp} />
             <CopyPopItem addNotification={addNotification} assetKey={traintupleKey} assetName="composite traintuple" />
             {headModelKey && <CopyPopItem addNotification={addNotification} assetKey={headModelKey} assetName="head model" />}
             {trunkModelKey && <CopyPopItem addNotification={addNotification} assetKey={trunkModelKey} assetName="trunk model" />}

--- a/src/app/business/routes/model/sagas/index.js
+++ b/src/app/business/routes/model/sagas/index.js
@@ -12,6 +12,7 @@ import {
 fetchListSaga, fetchPersistentSaga, setOrderSaga,
 } from '../../../common/sagas';
 import {signOut} from '../../../user/actions';
+import {listResults, itemResults} from '../selector';
 
 function* fetchList(request) {
     const state = yield select();
@@ -36,8 +37,9 @@ function* fetchList(request) {
 
 function* fetchDetail({payload}) {
     const state = yield select();
+    const modelDetailList = itemResults(state, 'model');
 
-    const item = state.model.item.results.find(o => o.traintuple.key === payload.traintuple.key);
+    const item = modelDetailList.find(o => o.traintuple.key === payload.traintuple.key);
 
     if (!item) {
         yield put(actions.item.success(payload));
@@ -66,14 +68,15 @@ function* fetchPersistent(request) {
     }
 }
 
-
 function* fetchBundleDetail() {
     const state = yield select();
+    const modelGroups = listResults(state, 'model');
+    const modelDetailList = itemResults(state, 'model');
 
-    for (const group of state.model.list.results) {
-        const models = group.filter(model => (model.traintuple && model.traintuple.tag) || (model.compositeTraintuple && model.compositeTraintuple.tag));
+    for (const group of modelGroups) {
+        const models = group.filter(model => model.traintuple && model.traintuple.tag);
         for (const model of models) {
-            const modelDetail = state.model.item.results.find(o => o.traintuple.key === model.traintuple.key);
+            const modelDetail = modelDetailList.find(o => o.traintuple.key === model.traintuple.key);
             if (!modelDetail) {
                 yield put(actions.item.request({id: model.traintuple.key}));
             }

--- a/src/app/business/routes/model/sagas/index.js
+++ b/src/app/business/routes/model/sagas/index.js
@@ -36,8 +36,7 @@ function* fetchList(request) {
 }
 
 function* fetchDetail({payload}) {
-    const state = yield select();
-    const modelDetailList = itemResults(state, 'model');
+    const modelDetailList = yield select(itemResults, 'model');
 
     const item = modelDetailList.find(o => o.traintuple.key === payload.traintuple.key);
 
@@ -69,9 +68,8 @@ function* fetchPersistent(request) {
 }
 
 function* fetchBundleDetail() {
-    const state = yield select();
-    const modelGroups = listResults(state, 'model');
-    const modelDetailList = itemResults(state, 'model');
+    const modelGroups = yield select(listResults, 'model');
+    const modelDetailList = yield select(itemResults, 'model');
 
     for (const group of modelGroups) {
         const models = group.filter(model => model.traintuple && model.traintuple.tag);

--- a/src/app/business/routes/model/sagas/index.js
+++ b/src/app/business/routes/model/sagas/index.js
@@ -71,7 +71,7 @@ function* fetchBundleDetail() {
     const state = yield select();
 
     for (const group of state.model.list.results) {
-        const models = group.filter(model => model.traintuple.tag);
+        const models = group.filter(model => (model.traintuple && model.traintuple.tag) || (model.compositeTraintuple && model.compositeTraintuple.tag));
         for (const model of models) {
             const modelDetail = state.model.item.results.find(o => o.traintuple.key === model.traintuple.key);
             if (!modelDetail) {

--- a/src/app/business/routes/model/selector.js
+++ b/src/app/business/routes/model/selector.js
@@ -12,11 +12,47 @@ export const flattenUniq = xs => Array.from(xs.reduce(
     new Set(),
 ));
 
-const listResults = (state, model) => state[model].list.results;
+
+const buildTypedTraintuple = (model) => {
+    let traintuple,
+        type;
+    if (model.compositeTraintuple) {
+        traintuple = model.compositeTraintuple;
+        type = 'composite';
+    }
+    else if (model.aggregatetuple) {
+        traintuple = model.aggregatetuple;
+        type = 'aggregate';
+    }
+    // it's necessary to put the "if (model.traintuple)" clause in last position
+    else if (model.traintuple) {
+        traintuple = model.traintuple;
+        type = 'standard';
+    }
+
+    return {
+        ...model,
+        traintuple: {
+            ...traintuple,
+            type,
+        },
+    };
+};
+
+
+const rawListResults = (state, model) => state[model].list.results;
 const selected = (state, model) => state[model].list.selected;
-const itemResults = (state, model) => state[model].item.results;
+const rawItemResults = (state, model) => state[model].item.results;
 const order = (state, model) => state[model].order;
 const isComplex = state => state.search.isComplex;
+
+export const listResults = createDeepEqualSelector([rawListResults],
+    results => results.map(models => models.map(buildTypedTraintuple)),
+);
+
+export const itemResults = createDeepEqualSelector([rawItemResults],
+    models => models.map(buildTypedTraintuple),
+);
 
 const itemResultsByKey = createDeepEqualSelector([itemResults],
     results => results.reduce((resultsByKey, result) => ({

--- a/src/app/business/search/sagas.js
+++ b/src/app/business/search/sagas.js
@@ -70,7 +70,7 @@ function* setFilters(request) {
         else if (item === 'dataset' && !dataset.persistent.init && !dataset.persistent.loading) {
             yield put(datasetActions.persistent.request());
         }
-        else if (item === 'algo' && !algo.persistent.init && !algo.persistent.loading) {
+        else if (['algo', 'composite_algo'].includes(item) && !algo.persistent.init && !algo.persistent.loading) {
             yield put(algoActions.persistent.request());
         }
         else if (item === 'model' && !model.persistent.init && !model.persistent.loading) {

--- a/src/app/business/search/sagas.js
+++ b/src/app/business/search/sagas.js
@@ -70,7 +70,7 @@ function* setFilters(request) {
         else if (item === 'dataset' && !dataset.persistent.init && !dataset.persistent.loading) {
             yield put(datasetActions.persistent.request());
         }
-        else if (['algo', 'composite_algo'].includes(item) && !algo.persistent.init && !algo.persistent.loading) {
+        else if (['algo', 'composite_algo', 'aggregate_algo'].includes(item) && !algo.persistent.init && !algo.persistent.loading) {
             yield put(algoActions.persistent.request());
         }
         else if (item === 'model' && !model.persistent.init && !model.persistent.loading) {

--- a/src/app/business/search/selector.js
+++ b/src/app/business/search/selector.js
@@ -29,21 +29,21 @@ const compositeAlgoResults = createDeepEqualSelector([algoResults],
     algoGroups => algoGroups && getAlgoByType(algoGroups, 'composite'),
 );
 
-export const outModelsHashes = createDeepEqualSelector([modelResults],
-    modelResults => modelResults && modelResults.length ? modelResults[0].filter(o => o.traintuple.outModel).map(o => ({hash: `hash:${o.traintuple.outModel.hash}`})) : modelResults,
+const traintupleKeys = createDeepEqualSelector([modelResults],
+    modelResults => modelResults && modelResults.length ? modelResults[0].map(o => ({key: (o.traintuple && o.traintuple.key) || (o.compositeTraintuple && o.compositeTraintuple.key)})) : modelResults,
 );
 
-export const getSearchFilters = createDeepEqualSelector([location, objectiveResults, datasetResults, standardAlgoResults, compositeAlgoResults, outModelsHashes],
-    (location, objective, dataset, standardAlgo, compositeAlgo, outModelsHashes) => ({
+export const getSearchFilters = createDeepEqualSelector([location, objectiveResults, datasetResults, standardAlgoResults, compositeAlgoResults, traintupleKeys],
+    (location, objective, dataset, standardAlgo, compositeAlgo, traintupleKeys) => ({
         objective: objective && objective.length ? objective[0] : objective,
         dataset: dataset && dataset.length ? dataset[0] : dataset,
         algo: standardAlgo,
         composite_algo: compositeAlgo,
-        model: outModelsHashes, // output model i.e trained model (updated)
+        model: traintupleKeys, // output model i.e trained model (updated)
         ...(location.type === 'MODEL' ? {
-            model_parents: outModelsHashes,
-            model_children: outModelsHashes,
-            model_family: outModelsHashes,
+            model_parents: traintupleKeys,
+            model_children: traintupleKeys,
+            model_family: traintupleKeys,
         } : {}),
     }),
 );

--- a/src/app/business/search/selector.js
+++ b/src/app/business/search/selector.js
@@ -1,3 +1,4 @@
+import {omit} from 'lodash';
 import {createDeepEqualSelector} from '../../utils/selector';
 
 const location = state => state.location;
@@ -9,15 +10,13 @@ const datasetResults = state => state.dataset ? state.dataset.persistent.results
 const algoResults = state => state.algo ? state.algo.persistent.results : null;
 const modelResults = state => state.model ? state.model.persistent.results : null;
 
-const removeProp = (o, prop) => {
-    const copy = {...o};
-    delete copy[prop];
-    return copy;
-};
 const getAlgoByType = (algoGroups, type) => algoGroups.reduce(
     (allAlgosOfType, group) => [
             ...allAlgosOfType,
-            ...group.filter(algo => algo.type === type).map(algo => removeProp(algo, 'type')),
+            ...group.reduce((algos, algo) => [
+                ...algos,
+                ...(algo.type === type ? [omit(algo, 'type')] : []),
+            ]),
         ],
     [],
 );

--- a/src/app/business/search/selector.js
+++ b/src/app/business/search/selector.js
@@ -28,17 +28,21 @@ const standardAlgoResults = createDeepEqualSelector([algoResults],
 const compositeAlgoResults = createDeepEqualSelector([algoResults],
     algoGroups => algoGroups && getAlgoByType(algoGroups, 'composite'),
 );
+const aggregateAlgoResults = createDeepEqualSelector([algoResults],
+    algoGroups => algoGroups && getAlgoByType(algoGroups, 'aggregate'),
+);
 
 const traintupleKeys = createDeepEqualSelector([modelResults],
     modelResults => modelResults && modelResults.length ? modelResults[0].map(o => ({key: (o.traintuple && o.traintuple.key) || (o.compositeTraintuple && o.compositeTraintuple.key)})) : modelResults,
 );
 
-export const getSearchFilters = createDeepEqualSelector([location, objectiveResults, datasetResults, standardAlgoResults, compositeAlgoResults, traintupleKeys],
-    (location, objective, dataset, standardAlgo, compositeAlgo, traintupleKeys) => ({
+export const getSearchFilters = createDeepEqualSelector([location, objectiveResults, datasetResults, standardAlgoResults, compositeAlgoResults, aggregateAlgoResults, traintupleKeys],
+    (location, objective, dataset, standardAlgo, compositeAlgo, aggregateAlgo, traintupleKeys) => ({
         objective: objective && objective.length ? objective[0] : objective,
         dataset: dataset && dataset.length ? dataset[0] : dataset,
         algo: standardAlgo,
         composite_algo: compositeAlgo,
+        aggregate_algo: aggregateAlgo,
         model: traintupleKeys, // output model i.e trained model (updated)
         ...(location.type === 'MODEL' ? {
             model_parents: traintupleKeys,


### PR DESCRIPTION
This PR adds support for composite and aggregate algos and models.

The API changes are:
* algos are now returned through 3 endpoints (`/algo`, `/composite_algo` and `/aggregate_algo`)
* `/model` returns objects that have either a `traintuple` or a `compositeTraintuple` or an `aggregatetuple`

# Algo page

* added `composite` and `aggregate` tags for the list pane
* added a  `type` metadata for the detail pane (with value either `Standard`, `Composite` or `Aggregate`)

![Capture d’écran 2019-11-26 à 16 35 25](https://user-images.githubusercontent.com/1270900/69648005-c5d6fc00-106a-11ea-8e33-85e1edd512e1.png)

# Model page

* added `composite` and `aggregate` tags for the list pane
* actions in the list pane now offer to copy the traintuple key or the model key for standard models
![Capture d’écran 2019-11-26 à 16 38 34](https://user-images.githubusercontent.com/1270900/69648271-439b0780-106b-11ea-91cd-64065c9bf049.png)
![Capture d’écran 2019-11-26 à 16 38 41](https://user-images.githubusercontent.com/1270900/69648272-439b0780-106b-11ea-8e0c-9f1d6e5ef33e.png)