### PR TITLE
Include credentials in requests made for the searchbar

### DIFF
--- a/src/app/business/routes/algo/sagas/index.js
+++ b/src/app/business/routes/algo/sagas/index.js
@@ -72,6 +72,29 @@ function* fetchItem({payload}) {
     }
 }
 
+
+function* fetchPersistent(request) {
+    const state = yield select();
+    let jwt;
+
+    if (typeof window !== 'undefined') {
+        const cookies = cookie.parse(window.document.cookie);
+        if (cookies['header.payload']) {
+            jwt = cookies['header.payload'];
+        }
+    }
+
+    if (!jwt) { // redirect to login page
+        yield put(actions.persistent.failure());
+        yield put(signOut.success());
+    }
+    else {
+        const f = () => fetchListApi(state.location.query, jwt);
+        yield call(fetchPersistentSaga(actions, f), request);
+    }
+}
+
+
 function* fetchDetail(request) {
     const state = yield select();
 
@@ -157,7 +180,7 @@ const sagas = function* sagas() {
     yield all([
         takeLatest(actionTypes.list.REQUEST, fetchList),
         takeLatest(actionTypes.list.SELECTED, fetchDetail),
-        takeLatest(actionTypes.persistent.REQUEST, fetchPersistentSaga(actions, fetchListApi)),
+        takeLatest(actionTypes.persistent.REQUEST, fetchPersistent),
 
         takeEvery(actionTypes.item.REQUEST, fetchItem),
 

--- a/src/app/business/routes/dataset/sagas/index.js
+++ b/src/app/business/routes/dataset/sagas/index.js
@@ -76,6 +76,28 @@ function* fetchItem({payload}) {
     }
 }
 
+function* fetchPersistent(request) {
+    const state = yield select();
+    let jwt;
+
+    if (typeof window !== 'undefined') {
+        const cookies = cookie.parse(window.document.cookie);
+        if (cookies['header.payload']) {
+            jwt = cookies['header.payload'];
+        }
+    }
+
+    if (!jwt) { // redirect to login page
+        yield put(actions.persistent.failure());
+        yield put(signOut.success());
+    }
+    else {
+        const f = () => fetchListApi(state.location.query, jwt);
+        yield call(fetchPersistentSaga(actions, f), request);
+    }
+}
+
+
 function* fetchDetail(request) {
     const state = yield select();
 
@@ -182,7 +204,7 @@ const sagas = function* sagas() {
     yield all([
         takeLatest(actionTypes.list.REQUEST, fetchList),
         takeLatest(actionTypes.list.SELECTED, fetchDetail),
-        takeLatest(actionTypes.persistent.REQUEST, fetchPersistentSaga(actions, fetchListApi)),
+        takeLatest(actionTypes.persistent.REQUEST, fetchPersistent),
 
         takeEvery(actionTypes.item.REQUEST, fetchItem),
 


### PR DESCRIPTION
Credentials were not included in requests made for the searchbar, which meant that there was no autocomplete of values (calls were rejected).