### PR TITLE
Increase network timeout limit during yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+network-timeout "300000"
+


### PR DESCRIPTION
This is to fix an issue we have with docker hub where the `yarn install` fails with timeout errors.