### PR TITLE
travis ci fix helm init 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       channel: stable
 
 before_script:
-  - helm init --client-only
+  - helm init
 
 script:
   - helm lint charts/substra-frontend


### PR DESCRIPTION
Since TravisCI is executing helm 3.0, and according to the migrate document https://helm.sh/docs/topics/v2_v3_migration/ the --client-only is not supported anymore as it is the default behavior.