### PR TITLE
Handle new "canceled" status

### DIFF
--- a/src/app/business/routes/model/bundleByTag.js
+++ b/src/app/business/routes/model/bundleByTag.js
@@ -12,7 +12,7 @@ const calcVariance = (arr) => {
 const calcStandardDeviation = arr => Math.sqrt(calcVariance(arr));
 
 function minStatus(models, getStatus) {
-    const statuses = ['failed', 'waiting', 'todo', 'doing', 'done'];
+    const statuses = ['failed', 'canceled', 'waiting', 'todo', 'doing', 'done'];
     const modelStatuses = uniqBy(models.map(m => getStatus(m)));
     for (const status of statuses) {
         if (modelStatuses.includes(status)) {

--- a/src/app/business/routes/model/components/detail/components/modelSummary.js
+++ b/src/app/business/routes/model/components/detail/components/modelSummary.js
@@ -65,6 +65,7 @@ const ModelSummary = ({model, addNotification}) => (
             (model.traintuple.status === 'todo' && <p>Preparing training.</p>)
             || (model.traintuple.status === 'doing' && <p>Undergoing training.</p>)
             || (model.traintuple.status === 'failed' && <p>Training failed.</p>)
+            || (model.traintuple.status === 'canceled' && <p>Training canceled.</p>)
             || (model.traintuple.status === 'done' && (
                 <Fragment>
                     {!model.testtuple && (
@@ -86,6 +87,8 @@ const ModelSummary = ({model, addNotification}) => (
                             && <p>Training successful. Undergoing testing.</p>)
                         || (model.testtuple.status === 'failed'
                             && <p>Training successful. Failed testing.</p>)
+                        || (model.testtuple.status === 'canceled'
+                            && <p>Training successful. Canceled testing.</p>)
                         || (model.testtuple.status === 'done' && (
                             <p>
                                 {'Model successfully trained with a score of '}

--- a/src/app/business/routes/model/components/detail/components/tabs/index.js
+++ b/src/app/business/routes/model/components/detail/components/tabs/index.js
@@ -116,6 +116,9 @@ class ModelTabs extends Component {
                         || (item.traintuple.status === 'failed' && (
                             <p>This model could not complete its training (no testing possible).</p>
                         ))
+                        || (item.traintuple.status === 'canceled' && (
+                            <p>This model got canceled (no testing possible).</p>
+                        ))
                         || (['waiting', 'todo', 'doing'].includes(item.traintuple.status) && (
                             <Fragment>
                                 <p>

--- a/src/app/business/routes/model/selector.js
+++ b/src/app/business/routes/model/selector.js
@@ -87,24 +87,28 @@ const modelOrder = order => (o) => {
                 1. done
                 2. doing
                 3. todo
-                4. failed
+                4. canceled
+                5. failed
             - we do not have a testtutple:
-                5. null
+                6. null
          - else traintuple status:
-                6. doing
-                7. todo
-                8. waiting
-                9. failed
+                7. doing
+                8. todo
+                9. waiting
+                10. canceled
+                11. failed
     */
 
     const scoreByStatus = {
-        failed: {null: -8},
-        waiting: {null: -7},
-        todo: {null: -6},
-        doing: {null: -5},
+        failed: {null: -10},
+        canceled: {null: -9},
+        waiting: {null: -8},
+        todo: {null: -7},
+        doing: {null: -6},
         done: {
-            null: -4,
-            failed: -3,
+            null: -5,
+            failed: -4,
+            canceled: -3,
             todo: -2,
             doing: -1,
             done: deepOrder(order),

--- a/src/app/business/search/fixtures/traintuples.js
+++ b/src/app/business/search/fixtures/traintuples.js
@@ -4,7 +4,7 @@ export const traintuples = [
         algo: {hash: '34563735737'},
         inModel: {hash: '34563735737'},
         outModel: {hash: '34563735737'},
-        status: 'done', // todo, done, training, trained, testing, failed
+        status: 'done', // todo, done, training, trained, testing, failed, canceled
         rank: 0,
         perf: 0.99,
         permissions: 'all',
@@ -15,7 +15,7 @@ export const traintuples = [
         algo: {hash: '34563735737'},
         inModel: {hash: '34563735737'},
         outModel: {hash: '34563735737'},
-        status: 'done', // todo, done, training, trained, testing, failed
+        status: 'done', // todo, done, training, trained, testing, failed, canceled
         rank: 0,
         perf: 0.99,
         permissions: 'all',


### PR DESCRIPTION
The `cancel-compute-plan` feature introduces a new `canceled` status for tuples that needs to be handled properly.

Related PR in the backend: https://github.com/SubstraFoundation/substra-backend/pull/65