### PR TITLE
Remove non-existing traintuple score

### DIFF
--- a/src/app/business/routes/model/components/detail/components/tabs/index.js
+++ b/src/app/business/routes/model/components/detail/components/tabs/index.js
@@ -1,4 +1,3 @@
-/* global SCORE_PRECISION */
 import React, {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import {noop} from 'lodash';
@@ -75,11 +74,7 @@ class ModelTabs extends Component {
                     <TabPanel>
                         {['standard', 'composite'].includes(tupleType) && item && item.traintuple && item.traintuple.status === 'done' && (
                         <p>
-                            {'Model successfully trained with a score of '}
-                            <b>{item.traintuple.dataset.perf.toFixed(SCORE_PRECISION)}</b>
-                            {' on '}
-                            <b>train data samples</b>
-                            .
+                            {'Model successfully trained.'}
                         </p>
                     )}
                         <CodeSample

--- a/src/app/business/search/selector.js
+++ b/src/app/business/search/selector.js
@@ -16,7 +16,7 @@ const getAlgoByType = (algoGroups, type) => algoGroups.reduce(
             ...group.reduce((algos, algo) => [
                 ...algos,
                 ...(algo.type === type ? [omit(algo, 'type')] : []),
-            ]),
+            ], []),
         ],
     [],
 );


### PR DESCRIPTION
The model detail pane used to display the "training" score of each traintuple. Since there's now no evaluation step attached to the training there is also no score. I removed the mention of this score.

I also fixed a "reduce" that missed its initial value.