### PR TITLE
Fix api url k8s

### DIFF
--- a/webpack/utils/plugins/definePlugin.js
+++ b/webpack/utils/plugins/definePlugin.js
@@ -1,15 +1,19 @@
 import webpack from 'webpack';
 import config from 'config';
 
+const IS_ELECTRON = JSON.stringify(process.env.IS_ELECTRON || 'false');
+
 export default () => new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
     'process.env.DEBUG_PROD': JSON.stringify(process.env.DEBUG_PROD || 'false'),
-    'process.env.IS_ELECTRON': JSON.stringify(process.env.IS_ELECTRON || 'false'),
+    'process.env.IS_ELECTRON': IS_ELECTRON,
     'process.env.IS_STATIC': JSON.stringify(process.env.IS_STATIC || 'false'),
     APP_NAME: JSON.stringify(config.appName),
-    // API_URL: JSON.stringify(config.apps.frontend.apiUrl), // needed for electron
     META_DESCRIPTION: JSON.stringify(config.apps.frontend.meta.description),
     PRODUCTION_BASE_NAME: JSON.stringify(config.apps.frontend.baseName.production),
     DEBUG_BASE_NAME: JSON.stringify(config.apps.frontend.baseName.debug),
     SCORE_PRECISION: JSON.stringify(config.apps.frontend.scorePrecision),
+    ...(IS_ELECTRON !== 'false' ? {
+        API_URL: JSON.stringify(config.apps.frontend.apiUrl), // needed for electron
+    } : {}),
 });

--- a/webpack/utils/plugins/definePlugin.js
+++ b/webpack/utils/plugins/definePlugin.js
@@ -7,7 +7,7 @@ export default () => new webpack.DefinePlugin({
     'process.env.IS_ELECTRON': JSON.stringify(process.env.IS_ELECTRON || 'false'),
     'process.env.IS_STATIC': JSON.stringify(process.env.IS_STATIC || 'false'),
     APP_NAME: JSON.stringify(config.appName),
-    API_URL: JSON.stringify(config.apps.frontend.apiUrl), // needed for electron
+    // API_URL: JSON.stringify(config.apps.frontend.apiUrl), // needed for electron
     META_DESCRIPTION: JSON.stringify(config.apps.frontend.meta.description),
     PRODUCTION_BASE_NAME: JSON.stringify(config.apps.frontend.baseName.production),
     DEBUG_BASE_NAME: JSON.stringify(config.apps.frontend.baseName.debug),


### PR DESCRIPTION
Adding API_URL to definePlugin made the skaffold version of the frontend fail. 

In the bundle that contained `user/api.js`, the global `API_URL` variable was undefined, which meant that login calls were made to `http://substra-frontend.node-1.com/undefined/user/login`.

Since adding this API_URL to definePlugin was required for electron, I modified the code to add it only in that case.