### PR TITLE
Simpler chunk name

### DIFF
--- a/src/app/business/common/routes/web.js
+++ b/src/app/business/common/routes/web.js
@@ -20,7 +20,7 @@ class UniversalRoute extends Component {
         const U = universal(import(`../../routes/${model}/preload/index`), {
             loading: <PulseLoader />,
             ignoreBabelRename: true,
-            chunkName: () => `routes/${model}/preload/index`.replace(/(?<=\/.*)\//g, '-'),
+            chunkName: () => `routes/${model}-preload-index`,
             onLoad: (module, info, {reduxcontext}) => {
                 if (reduxcontext && reduxcontext.store) {
                     injectSaga(model, module.sagas, false, reduxcontext.store);


### PR DESCRIPTION
The chunkName callback relied on a regex with a positive lookbehind clause which isn't supported in FF at the moment. Since we can predict the output of the regex replace (model will never contain a `/`), we can replace it with the target value.