### PR TITLE
Fix skaffold build

### DIFF
--- a/webpack/utils/plugins/definePlugin.js
+++ b/webpack/utils/plugins/definePlugin.js
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import config from 'config';
 
-const IS_ELECTRON = JSON.stringify(process.env.IS_ELECTRON || 'false');
+const IS_ELECTRON = JSON.stringify(process.env.IS_ELECTRON || false);
 
 export default () => new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),


### PR DESCRIPTION
The `IS_ELECTRON` value was the string `"false"` by default instead of being the string `false`, which made the check on L16 return true everytime.