### PR TITLE
Refactor sagas

### DIFF
--- a/src/app/business/routes/dataset/sagas/index.js
+++ b/src/app/business/routes/dataset/sagas/index.js
@@ -1,36 +1,18 @@
-/* globals fetch */
-
 import {
     all, call, put, select, takeEvery, takeLatest,
 } from 'redux-saga/effects';
 
-import {saveAs} from 'file-saver';
-
 import actions, {actionTypes} from '../actions';
 import {fetchItemApi, fetchListApi} from '../api';
 import {
-    fetchItemSaga, fetchListSaga, fetchPersistentSaga, getJWTFromCookie, setOrderSaga, tryRefreshToken,
-    fetchItemDescriptionSaga,
+    setOrderSaga, fetchItemDescriptionSagaFactory, fetchListSagaFactory,
+    fetchItemSagaFactory, downloadItemSagaFactory, withJWT,
 } from '../../../common/sagas';
 import {fetchRaw} from '../../../../entities/fetchEntities';
 import {getItem} from '../../../common/selector';
 
 
-function* fetchList(request) {
-    const state = yield select();
-
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.list.failure);
-    }
-
-    if (jwt) {
-        const f = () => fetchListApi(state.location.query, jwt);
-        yield call(fetchListSaga(actions, f), request);
-    }
-}
-
-function* manageTabs(tabIndex) {
+function* fetchTabContentSaga({payload: tabIndex}) {
     const state = yield select();
     const item = getItem(state, 'dataset');
 
@@ -44,120 +26,48 @@ function* manageTabs(tabIndex) {
     }
 }
 
-function* fetchItem({payload}) {
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.item.failure);
-    }
-
-    if (jwt) {
-        yield call(fetchItemSaga(actions, fetchItemApi), {
-            payload: {
-                id: payload.key,
-                get_parameters: {},
-                jwt,
-            },
-        });
-    }
-}
-
-function* fetchPersistent(request) {
-    const state = yield select();
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.persistent.failure);
-    }
-
-    if (jwt) {
-        const f = () => fetchListApi(state.location.query, jwt);
-        yield call(fetchPersistentSaga(actions, f), request);
-    }
-}
-
-
-function* fetchDetail(request) {
+function* fetchDetailSaga({payload}) {
     const state = yield select();
 
     // fetch current tab content if needed
-    yield manageTabs(state.dataset.item.tabIndex);
+    yield put(actions.item.tabIndex.set(state.dataset.item.tabIndex));
 
-    const exists = state.dataset.item.results.find((o) => o.pkhash === request.payload.key);
+    const exists = state.dataset.item.results.find((o) => o.pkhash === payload.key);
     if (!exists) {
-        yield put(actions.item.request(request.payload));
+        yield put(actions.item.request(payload));
     }
 }
 
-function* setTabIndexSaga({payload}) {
-    yield manageTabs(payload);
-}
-
-function* fetchItemOpenerSaga({payload: {pkhash, url}}) {
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.opener.failure);
+function* innerFetchItemOpenerSaga(jwt, {payload: {pkhash, url}}) {
+    const {res, error, status} = yield call(fetchRaw, url, jwt);
+    if (res && status === 200) {
+        yield put(actions.item.opener.success({pkhash, openerContent: res}));
     }
-
-    if (jwt) {
-        const {res, error, status} = yield call(fetchRaw, url, jwt);
-        if (res && status === 200) {
-            yield put(actions.item.opener.success({pkhash, openerContent: res}));
-        }
-        else {
-            console.error(error, status);
-            yield put(actions.item.opener.failure({pkhash, status}));
-        }
+    else {
+        console.error(error, status);
+        yield put(actions.item.opener.failure({pkhash, status}));
     }
 }
 
-function* downloadItemSaga({payload: {url}}) {
-    let status;
-    let filename;
-
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.download.failure);
-    }
-
-    if (jwt) {
-        yield fetch(url, {
-            headers: {
-                Accept: 'application/json;version=0.0',
-                ...(jwt ? {Authorization: `JWT ${jwt}`} : {}),
-            },
-            credentials: 'include',
-            mode: 'cors',
-        }).then((response) => {
-            status = response.status;
-            if (!response.ok) {
-                return response.text().then((result) => Promise.reject(new Error(result)));
-            }
-
-            filename = response.headers.get('Content-Disposition').split('filename=')[1].replace(/"/g, '');
-
-            return response.blob();
-        }).then((res) => {
-            saveAs(res, filename);
-        }, (error) => ({error, status}));
-    }
-}
+const fetchItemOpenerSaga = withJWT(innerFetchItemOpenerSaga, actions.item.opener.failure);
 
 
 /* istanbul ignore next */
 const sagas = function* sagas() {
     yield all([
-        takeLatest(actionTypes.list.REQUEST, fetchList),
-        takeLatest(actionTypes.list.SELECTED, fetchDetail),
-        takeLatest(actionTypes.persistent.REQUEST, fetchPersistent),
+        takeLatest(actionTypes.list.REQUEST, fetchListSagaFactory(actions.list, fetchListApi)),
+        takeLatest(actionTypes.list.SELECTED, fetchDetailSaga),
+        takeLatest(actionTypes.persistent.REQUEST, fetchListSagaFactory(actions.persistent, fetchListApi)),
 
-        takeEvery(actionTypes.item.REQUEST, fetchItem),
+        takeEvery(actionTypes.item.REQUEST, fetchItemSagaFactory(actions.item, fetchItemApi)),
 
-        takeLatest(actionTypes.item.description.REQUEST, fetchItemDescriptionSaga(actions)),
+        takeLatest(actionTypes.item.description.REQUEST, fetchItemDescriptionSagaFactory(actions.item.description)),
         takeLatest(actionTypes.item.opener.REQUEST, fetchItemOpenerSaga),
 
-        takeEvery(actionTypes.item.download.REQUEST, downloadItemSaga),
+        takeEvery(actionTypes.item.download.REQUEST, downloadItemSagaFactory(actions.item.download)),
 
         takeLatest(actionTypes.order.SET, setOrderSaga),
-        takeLatest(actionTypes.item.tabIndex.SET, setTabIndexSaga),
+        takeLatest(actionTypes.item.tabIndex.SET, fetchTabContentSaga),
     ]);
 };
 

--- a/src/app/business/routes/model/api.js
+++ b/src/app/business/routes/model/api.js
@@ -1,7 +1,7 @@
-import {fetchEntitiesFactory, fetchEntitiesByPathFactory} from '../../../entities/fetchEntities';
+import {fetchEntitiesFactory, fetchEntityFactory} from '../../../entities/fetchEntities';
 
 export const fetchListApi = fetchEntitiesFactory('model');
-export const fetchItemApi = fetchEntitiesByPathFactory('model', 'details');
+export const fetchItemApi = fetchEntityFactory('model');
 
 export default {
     fetchListApi,

--- a/src/app/business/routes/objective/sagas/index.js
+++ b/src/app/business/routes/objective/sagas/index.js
@@ -1,33 +1,17 @@
-/* globals fetch */
-
 import {
-    takeLatest, takeEvery, all, select, call, put,
+    takeLatest, takeEvery, all, select, put,
 } from 'redux-saga/effects';
-
-import {saveAs} from 'file-saver';
 
 import actions, {actionTypes} from '../actions';
 import {fetchListApi, fetchItemApi} from '../api';
 import {
-    fetchListSaga, fetchPersistentSaga, fetchItemSaga, setOrderSaga, getJWTFromCookie, tryRefreshToken,
-    fetchItemDescriptionSaga,
+    setOrderSaga,
+    fetchItemDescriptionSagaFactory, fetchListSagaFactory, fetchItemSagaFactory, downloadItemSagaFactory,
 } from '../../../common/sagas';
 import {getItem} from '../../../common/selector';
 
-function* fetchList(request) {
-    const state = yield select();
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.list.failure);
-    }
 
-    if (jwt) {
-        const f = () => fetchListApi(state.location.query, jwt);
-        yield call(fetchListSaga(actions, f), request);
-    }
-}
-
-function* manageTabs(tabIndex) {
+function* fetchTabContentSaga({payload: tabIndex}) {
     const state = yield select();
     const item = getItem(state, 'objective');
 
@@ -38,98 +22,32 @@ function* manageTabs(tabIndex) {
     }
 }
 
-function* fetchItem({payload}) {
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.item.failure);
-    }
-
-    if (jwt) {
-        yield call(fetchItemSaga(actions, fetchItemApi), {
-            payload: {
-                id: payload.key,
-                get_parameters: {},
-                jwt,
-            },
-        });
-    }
-}
-
-function* fetchPersistent(request) {
-    const state = yield select();
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.persistent.failure);
-    }
-
-    if (jwt) {
-        const f = () => fetchListApi(state.location.query, jwt);
-        yield call(fetchPersistentSaga(actions, f), request);
-    }
-}
-
-function* fetchDetail(request) {
+function* fetchDetailSaga({payload: {key}}) {
     const state = yield select();
 
     // fetch current tab content if needed
-    yield manageTabs(state.objective.item.tabIndex);
+    yield put(actions.item.tabIndex.set(state.objective.item.tabIndex));
 
-    const exists = state.objective.item.results.find((o) => o.pkhash === request.payload.key);
+    const exists = state.objective.item.results.find((o) => o.pkhash === key);
     if (!exists) {
-        yield put(actions.item.request(request.payload));
-    }
-}
-
-function* setTabIndexSaga({payload}) {
-    yield manageTabs(payload);
-}
-
-
-function* downloadItemSaga({payload: {url}}) {
-    let status;
-    let filename;
-
-    let jwt = getJWTFromCookie();
-    if (!jwt) {
-        jwt = yield tryRefreshToken(actions.description.failure);
-    }
-    if (jwt) {
-        yield fetch(url, {
-            headers: {
-                Accept: 'application/json;version=0.0',
-                ...(jwt ? {Authorization: `JWT ${jwt}`} : {}),
-            },
-            credentials: 'include',
-            mode: 'cors',
-        }).then((response) => {
-            status = response.status;
-            if (!response.ok) {
-                return response.text().then((result) => Promise.reject(new Error(result)));
-            }
-
-            filename = response.headers.get('Content-Disposition').split('filename=')[1].replace(/"/g, '');
-
-            return response.blob();
-        }).then((res) => {
-            saveAs(res, filename);
-        }, (error) => ({error, status}));
+        yield put(actions.item.request({key}));
     }
 }
 
 /* istanbul ignore next */
 const sagas = function* sagas() {
     yield all([
-        takeLatest(actionTypes.list.REQUEST, fetchList),
-        takeLatest(actionTypes.list.SELECTED, fetchDetail),
-        takeLatest(actionTypes.persistent.REQUEST, fetchPersistent),
+        takeLatest(actionTypes.list.REQUEST, fetchListSagaFactory(actions.list, fetchListApi)),
+        takeLatest(actionTypes.list.SELECTED, fetchDetailSaga),
+        takeLatest(actionTypes.persistent.REQUEST, fetchListSagaFactory(actions, fetchListApi)),
 
-        takeEvery(actionTypes.item.REQUEST, fetchItem),
-        takeLatest(actionTypes.item.description.REQUEST, fetchItemDescriptionSaga(actions)),
+        takeEvery(actionTypes.item.REQUEST, fetchItemSagaFactory(actions.item, fetchItemApi)),
+        takeLatest(actionTypes.item.description.REQUEST, fetchItemDescriptionSagaFactory(actions.item.description)),
 
-        takeEvery(actionTypes.item.download.REQUEST, downloadItemSaga),
+        takeEvery(actionTypes.item.download.REQUEST, downloadItemSagaFactory(actions.item.download)),
 
         takeLatest(actionTypes.order.SET, setOrderSaga),
-        takeLatest(actionTypes.item.tabIndex.SET, setTabIndexSaga),
+        takeLatest(actionTypes.item.tabIndex.SET, fetchTabContentSaga),
     ]);
 };
 


### PR DESCRIPTION
There was a lot of duplicated code in our sagas, as well as inconsistent naming throughout. This PR simplifies this all by:
- creating a handy `withJWT` decorator
- providing saga factories for default behavior
- mutualizing code between list and persistent sagas (was doing the exact same thing but with different actions)