### PR TITLE
Specify which version of node to use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ skaffold.yaml
 
  # NPM dependencies
 node_modules/
-yarn.lock
 package-lock.json
 
  # Other

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:12.16.1-alpine AS build
 
 RUN apk add python2 make g++
 
@@ -9,6 +9,7 @@ COPY packages/ssr /workspace/packages/ssr
 COPY packages/base /workspace/packages/base
 COPY packages/plugins  /workspace/packages/plugins
 COPY .yarnrc /workspace
+COPY yarn.lock  /workspace
 
 RUN yarn config list
 RUN yarn install
@@ -20,7 +21,7 @@ ENV NODE_ENV=production
 
 RUN yarn build:main
 
-FROM node:alpine
+FROM node:12.16.1-alpine
 
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Installation
 
-This project use yarn and the experimental yarn workspaces for package.json splitting and convenience.
+This project is guaranteed to work with Node.JS version `12.16.1 LTS` but should also work with newer versions.
+
+It uses yarn and the experimental yarn workspaces for package.json splitting and convenience.
 
 Please install the last version of yarn and run:<br/>
 `yarn config set workspaces-experimental true`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/SubstraFoundation/substra-frontend"
     },
     "engines": {
-        "node": ">=8.4.0",
+        "node": "~12.16.1",
         "npm": ">=5.3.0"
     },
     "workspaces": [


### PR DESCRIPTION
We ran into a bug created by node 13: https://github.com/babel/babel/issues/11216

By specifying which version to use in the dockerfiles and using the yarn.lock for packages, we can make sure we control the content of the container.