### PR TITLE
Remove redis cache

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,4 @@
 API_URL=http://substra-backend.owkin.xyz:8000
 
-REDIS_HOST=redis
-REDIS_PORT=6379
 NODE_PORT=8000
 SECURE_NODE_PORT=8443

--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Please install the last version of yarn and run:<br/>
 Then run:<br/>
 `yarn install`
 
-You also need a redis server on your machine.<br/>
-On linux, simple run:<br/>
-`sudo apt install redis`
-
-And make sure the redis server is running by executing:<br/>
-`redis-cli`
-
-
 For testing and developing on the project with true hot module replacement, run
 `yarn start`
 Then head to `http://substra-frontend.owkin.xyz:3000/` `substra-backend.owkin.xyz` is important for working with same site cookie policy
@@ -46,16 +38,10 @@ yarn deploy
 
 You can now stop the task on aws ECS, it will restart automatically, if you did not define an autoscaling policy.
 
-Do no forget to invalidate the cache on your aws redis instance.
-Connect with ssh to your ec2 instance, then connect to your redis instance as explain in elasticache documentation.
-https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/GettingStarted.ConnectToCacheNode.html#GettingStarted.ConnectToCacheNode.Redis.NoEncrypt
-Then run `flushall`. You should automatize this part.
-More information in the cache part below.
-
 ## Docker launch
 
-The `docker-compose.yaml` file will launch substra-frontend and redis docker instances.
-substra-frontend will be launch with prod settings, which is a bit different from the settings.
+The `docker-compose.yaml` file will launch a substra-frontend docker instance.
+It will be launch with prod settings, which is a bit different from the settings.
 Launch it with:
 ```bash
 $> docker-compose up -d --force-recreate
@@ -65,9 +51,6 @@ If you want to update the docker images, execute:
 ```bash
 $> docker-compose up -d --force-recreate --build
 ```
-
-If your substra-backend instance use basicauth settings, you need to pass the `BACK_AUTH_USER` and `BACK_AUTH_PASSWORD` variables to your current environment for not triggering 403 responses.
-
 
 ## Substra-UI
 
@@ -118,28 +101,6 @@ If you are using Webstorm, you can use the jest configuration for easily debuggi
 
 For displaying lint errors:
 `yarn eslint`
-
-## Cache
-
-This project use a redis cache manager for the server routes. Allowing us not to rerender the same html production by route.
-For deploying with amazon, please create a redis cluster by following this documentation:
-https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/GettingStarted.CreateCluster.html
-Don't forget to create a isolated security group for opening port 6379 as described in the documentation.
-
-### test
-For testing your generated docker with your localhosted redis, update your `deploy.js` file and do not forget to comment the part that push to your registry, then:
-```shell
-$> redis-cli flushall && docker run -it -v /etc/letsencrypt/:/etc/letsencrypt/ --net="host" -p 8000:3000 docker_image_name:latest
-```
-
-You'll notice I also bind the let's encrypt folder, more information in the next part.
-
-Then head to `https://substra-backend.owkin.xyz:3000/`
-:warning: Be sure to use `substra-backend.owkin.xyz` and not `localhost` or `127.0.0.1` for being able to work with cookies.
-
-Do not forget to `redis-cli flushall` when testing multiple times.
-
-Disable redis for testing this project in ssl with `-p 8001:8443`.
 
 ## Encryption files creation
 

--- a/charts/substra-frontend/requirements.lock
+++ b/charts/substra-frontend/requirements.lock
@@ -1,6 +1,3 @@
-dependencies:
-- name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 10.0.2
-digest: sha256:e65fb8f03fb67e950ae15ad8d693ea7c300c9818bae2a00eca3a818dbb56694c
-generated: "2020-02-06T16:03:56.607929+01:00"
+dependencies: []
+digest: sha256:a4028ef6b5df0ba52501af1116d232a75056093f30ddf3b725e34fff764048c2
+generated: "2020-04-27T14:19:49.55627+02:00"

--- a/charts/substra-frontend/requirements.yaml
+++ b/charts/substra-frontend/requirements.yaml
@@ -1,5 +1,1 @@
 dependencies:
-  - name: redis
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    version: ~10.0.0
-    condition: redis.enabled

--- a/charts/substra-frontend/templates/deployment.yaml
+++ b/charts/substra-frontend/templates/deployment.yaml
@@ -37,10 +37,6 @@ spec:
           {{- end }}
           command: ["./node_modules/.bin/babel-node", "./build/ssr/index.js"]
           env:
-            - name: REDIS_PORT
-              value: {{ .Values.redis.port | quote }}
-            - name: REDIS_HOST
-              value: "{{ .Release.Name }}-{{ .Values.redis.host }}"
             - name: API_URL
               value: {{ .Values.api.url | quote }}
             - name: NODE_PORT

--- a/charts/substra-frontend/values.yaml
+++ b/charts/substra-frontend/values.yaml
@@ -52,15 +52,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-redis:
-  port: 6379
-  host: redis-master
-  enabled: true
-  usePassword: false
-  cluster:
-    enabled: false
-  master:
-    disableCommands: []
-    persistence:
-      enabled: false

--- a/config/default.js
+++ b/config/default.js
@@ -5,8 +5,6 @@ const apiUrl = 'http://substra-backend.owkin.xyz:8000';
 const ravenUrl = process.env.FRONT_RAVEN_URL || '';
 const encryption_privkey = './encryption/ca.key';
 const encryption_fullchain = './encryption/ca.crt';
-const redis_host = process.env.REDIS_HOST || 'localhost';
-const redis_port = process.env.REDIS_PORT || 6379;
 
 module.exports = {
     appName: 'Substra',
@@ -29,9 +27,5 @@ module.exports = {
     encryption: {
         privkey: encryption_privkey,
         fullchain: encryption_fullchain,
-    },
-    redis: {
-        host: redis_host,
-        redis: redis_port,
     },
 };

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,19 +11,10 @@ services:
       context: ./
     container_name: substra-frontend
     hostname: substra-frontend
-    depends_on:
-      - redis
     ports:
       - "3000:8000"
     restart: unless-stopped
     environment:
       - API_URL=$API_URL
-      - REDIS_HOST=$REDIS_HOST
-      - REDIS_PORT=$REDIS_PORT
       - NODE_PORT=$NODE_PORT
       - SECURE_NODE_PORT=$SECURE_NODE_PORT
-  redis:
-    container_name: redis
-    hostname: redis
-    image: redis:4.0.11-alpine
-    restart: unless-stopped

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -101,7 +101,6 @@
         "koa-webpack-dev-middleware": "2.0.2",
         "lodash-webpack-plugin": "0.11.5",
         "query-string": "6.10.1",
-        "redis": "2.8.0",
         "stats-webpack-plugin": "0.7.0",
         "sw-precache-webpack-plugin": "0.11.5",
         "terser-webpack-plugin": "2.3.2",

--- a/tools/deploy_template.js
+++ b/tools/deploy_template.js
@@ -10,12 +10,10 @@ const tag = `${year}.${month}.${timestamp}`;
 const registry = 'your_amazon_ecs_repository';
 const name = 'image_name';
 const raven_url = 'your_raven_url';
-const redis_host = 'your_redis_host_url';  // use '127.0.0.1'; for testing on your localhost
-const redis_port = 6379;
 
 console.log(`Deploying ${registry}/${name}:${tag}`);
 
 const branch_name = shell.exec('git symbolic-ref --short HEAD', {silent: true}).stdout.replace(/\n/g, '');
 
-shell.exec(`docker build --build-arg raven_url=${raven_url} --build-arg redis_host=${redis_host} --build-arg redis_port=${redis_port} -t ${registry}/${name}:${tag} -t ${registry}/${name}:${branch_name} -t ${registry}/${name}:latest .`);
+shell.exec(`docker build --build-arg raven_url=${raven_url} -t ${registry}/${name}:${tag} -t ${registry}/${name}:${branch_name} -t ${registry}/${name}:latest .`);
 shell.exec(`docker push ${registry}/${name}:latest && docker push ${registry}/${name}:${tag} && docker push ${registry}/${name}:${branch_name}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,11 +4874,6 @@ dotenv@^8.0.0, dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
-double-ended-queue@^2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
-  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
-
 downshift@3.2.12:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.2.12.tgz#19dc3b38e2d070c814f25d67d3a430e1bd25cf74"
@@ -11769,25 +11764,6 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
-
-redis-commands@^1.2.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
-  integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
-
-redis-parser@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
-  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
-
-redis@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
-  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
-  dependencies:
-    double-ended-queue "^2.1.0-0"
-    redis-commands "^1.2.0"
-    redis-parser "^2.6.0"
 
 reduce-reducers@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
With the introduction of user credentials, our redis cache use has been reduced to caching on the `/404` route. This very minimal benefit was made at the cost of added complexity in our development and deployment setups (needs for a redis instance) and required quite a bit of code and documentation.

This PR removes the redis cache and the dependency on redis entirely.

This change can be tested with:
* local env: `yarn start` should not fail if redis isn't present locally
* docker-compose: no more `redis` container
* skaffold dev: no more `redis` container