### PR TITLE
Add user metadata

### DIFF
--- a/src/app/business/common/components/detail/components/metadata.js
+++ b/src/app/business/common/components/detail/components/metadata.js
@@ -36,13 +36,14 @@ const baseDd = css`
 const metadataDt = css`
     text-transform: initial;
     font-family: ${monospaceFamily};
-    margin-left: ${spacingSmall};
+    padding-left: ${spacingSmall};
+    &:before {
+        content: '- ';
+    }
 `;
 
 const metadataDd = css`
-    font-family: ${monospaceFamily};
-    margin-left: -${spacingSmall};
-`;
+    font-family: ${monospaceFamily};`;
 
 export const clipboard = css`
     position: absolute;
@@ -179,7 +180,7 @@ export const MetadataMetadata = ({metadata}) => {
         <>
             <SingleMetadata label="Metadata" />
             {keys.map((key) => (
-                <SingleMetadata labelClassName={metadataDt} valueClassName={metadataDd} key={key} label={`- ${key}`} value={metadata[key]} />))}
+                <SingleMetadata labelClassName={metadataDt} valueClassName={metadataDd} key={key} label={key} value={metadata[key]} />))}
         </>
         ) : <SingleMetadata label="Metadata" value="N/A" />
     );

--- a/src/app/business/common/components/detail/components/metadata.js
+++ b/src/app/business/common/components/detail/components/metadata.js
@@ -35,10 +35,13 @@ const baseDd = css`
 
 const metadataDt = css`
     text-transform: initial;
+    font-family: ${monospaceFamily};
+    margin-left: ${spacingSmall};
 `;
 
 const metadataDd = css`
     font-family: ${monospaceFamily};
+    margin-left: -${spacingSmall};
 `;
 
 export const clipboard = css`
@@ -170,15 +173,15 @@ OwnerMetadata.defaultProps = {
 };
 
 export const MetadataMetadata = ({metadata}) => {
-    const keys = Object.keys(metadata);
+    const keys = Object.keys(metadata).sort();
 
     return (keys.length ? (
         <>
             <SingleMetadata label="Metadata" />
-            {keys.sort().map((key) => (
-                <SingleMetadata labelClassName={metadataDt} valueClassName={metadataDd} key={key} label={key} value={metadata[key]} />))}
+            {keys.map((key) => (
+                <SingleMetadata labelClassName={metadataDt} valueClassName={metadataDd} key={key} label={`- ${key}`} value={metadata[key]} />))}
         </>
-        ) : <SingleMetadata label="Metadata">N/A</SingleMetadata>
+        ) : <SingleMetadata label="Metadata" value="N/A" />
     );
 };
 

--- a/src/app/business/common/components/detail/components/metadata.js
+++ b/src/app/business/common/components/detail/components/metadata.js
@@ -160,6 +160,38 @@ OwnerMetadata.defaultProps = {
     owner: '',
 };
 
+export const MetadataMetadata = ({metadata}) => {
+    const keys = Object.keys(metadata);
+
+    const li = css`
+        font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace
+    `;
+
+    return (
+        <SingleMetadata label="Metadata">
+            {keys.length ? (
+                <ul>
+                    {keys.sort().map((key) => (
+                        <li className={li} key={key}>
+                            {key}
+                            :
+                            {metadata[key]}
+                        </li>
+                    ))}
+                </ul>
+            ) : 'N/A'}
+        </SingleMetadata>
+    );
+};
+
+MetadataMetadata.propTypes = {
+    metadata: PropTypes.shape(),
+};
+
+MetadataMetadata.defaultProps = {
+    metadata: {},
+};
+
 PermissionsMetadata.propTypes = {
     permissions: PropTypes.shape({
         request: PropTypes.shape({

--- a/src/app/business/common/components/detail/components/metadata.js
+++ b/src/app/business/common/components/detail/components/metadata.js
@@ -6,6 +6,7 @@ import {capitalize, noop} from 'lodash';
 
 import {spacingExtraSmall, spacingSmall} from '../../../../../../../assets/css/variables/spacing';
 import {blueGrey} from '../../../../../../../assets/css/variables/colors';
+import {monospaceFamily} from '../../../../../../../assets/css//variables/font';
 import CopyInput from './copyInput';
 
 const LABEL_WIDTH = '200';
@@ -30,6 +31,14 @@ const baseDd = css`
     margin-left: 0;
     width: calc(100% - ${LABEL_WIDTH}px);
     margin-bottom: ${spacingExtraSmall};
+`;
+
+const metadataDt = css`
+    text-transform: initial;
+`;
+
+const metadataDd = css`
+    font-family: ${monospaceFamily};
 `;
 
 export const clipboard = css`
@@ -163,24 +172,13 @@ OwnerMetadata.defaultProps = {
 export const MetadataMetadata = ({metadata}) => {
     const keys = Object.keys(metadata);
 
-    const li = css`
-        font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace
-    `;
-
-    return (
-        <SingleMetadata label="Metadata">
-            {keys.length ? (
-                <ul>
-                    {keys.sort().map((key) => (
-                        <li className={li} key={key}>
-                            {key}
-                            :
-                            {metadata[key]}
-                        </li>
-                    ))}
-                </ul>
-            ) : 'N/A'}
-        </SingleMetadata>
+    return (keys.length ? (
+        <>
+            <SingleMetadata label="Metadata" />
+            {keys.sort().map((key) => (
+                <SingleMetadata labelClassName={metadataDt} valueClassName={metadataDd} key={key} label={key} value={metadata[key]} />))}
+        </>
+        ) : <SingleMetadata label="Metadata">N/A</SingleMetadata>
     );
 };
 

--- a/src/app/business/routes/algo/components/detail/components/metadata.js
+++ b/src/app/business/routes/algo/components/detail/components/metadata.js
@@ -4,7 +4,11 @@ import {capitalize} from 'lodash';
 import BaseMetadata, {
     MetadataWrapper,
     KeyMetadata,
-    BrowseRelatedMetadata, PermissionsMetadata, OwnerMetadata, SingleMetadata,
+    BrowseRelatedMetadata,
+    PermissionsMetadata,
+    OwnerMetadata,
+    SingleMetadata,
+    MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import BrowseRelatedLinks from './browseRelatedLinks';
 
@@ -15,6 +19,7 @@ const Metadata = ({item, addNotification, model}) => (
         <SingleMetadata label="Type" value={capitalize(item.type)} />
         <OwnerMetadata owner={item.owner} />
         <PermissionsMetadata permissions={item.permissions} />
+        <MetadataMetadata metadata={item.metadata} />
         <BrowseRelatedMetadata>
             <BrowseRelatedLinks item={item} />
         </BrowseRelatedMetadata>

--- a/src/app/business/routes/dataset/components/detail/components/metadata.js
+++ b/src/app/business/routes/dataset/components/detail/components/metadata.js
@@ -5,7 +5,10 @@ import {
     KeyMetadata,
     BrowseRelatedMetadata,
     MetadataInterface,
-    MetadataWrapper, PermissionsMetadata, OwnerMetadata,
+    MetadataWrapper,
+    PermissionsMetadata,
+    OwnerMetadata,
+    MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 
 const Metadata = ({item, addNotification, model}) => (
@@ -13,6 +16,7 @@ const Metadata = ({item, addNotification, model}) => (
         <KeyMetadata item_key={item.key} addNotification={addNotification} model={model} />
         <OwnerMetadata owner={item.owner} />
         <PermissionsMetadata permissions={item.permissions} />
+        <MetadataMetadata metadata={item.metadata} />
         <BrowseRelatedMetadata>
             <BrowseRelatedLinks item={item} />
         </BrowseRelatedMetadata>

--- a/src/app/business/routes/model/components/detail/components/metadata.js
+++ b/src/app/business/routes/model/components/detail/components/metadata.js
@@ -9,6 +9,7 @@ import BaseMetadata, {
     keyValueClassName,
     BrowseRelatedMetadata,
     PermissionsMetadata,
+    MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import CopyInput from '../../../../../common/components/detail/components/copyInput';
 import BrowseRelatedLinks from './browseRelatedLinks';
@@ -69,6 +70,7 @@ class Metadata extends Component {
                 <SingleMetadata label="Creator" value={item.traintuple.creator} />
                 <SingleMetadata label="Worker" value={type === 'aggregate' ? item.traintuple.worker : item.traintuple.dataset.worker} />
                 <PermissionsMetadata permissions={item.traintuple.permissions} />
+                <MetadataMetadata metadata={item.metadata} />
                 <BrowseRelatedMetadata>
                     <BrowseRelatedLinks item={item} />
                 </BrowseRelatedMetadata>

--- a/src/app/business/routes/model/components/detail/components/metadata.js
+++ b/src/app/business/routes/model/components/detail/components/metadata.js
@@ -55,8 +55,8 @@ class Metadata extends Component {
                 {type === 'composite' && (
                     <>
                         <KeyMetadata addNotification={this.addNotification} assetName="composite traintuple" assetKey={item.traintuple.key} />
-                        <KeyMetadata addNotification={this.addNotification} assetName="head model" assetKey={item.traintuple.outHeadModel ? item.traintuple.outHeadModel.outModel.hash : 'N/A'} />
-                        <KeyMetadata addNotification={this.addNotification} assetName="trunk model" assetKey={item.traintuple.outTrunkModel ? item.traintuple.outTrunkModel.outModel.hash : 'N/A'} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="head model" assetKey={item.traintuple.outHeadModel.outModel ? item.traintuple.outHeadModel.outModel.hash : 'N/A'} />
+                        <KeyMetadata addNotification={this.addNotification} assetName="trunk model" assetKey={item.traintuple.outTrunkModel.outModel ? item.traintuple.outTrunkModel.outModel.hash : 'N/A'} />
                     </>
                 )}
                 {type === 'aggregate' && (
@@ -70,7 +70,7 @@ class Metadata extends Component {
                 <SingleMetadata label="Creator" value={item.traintuple.creator} />
                 <SingleMetadata label="Worker" value={type === 'aggregate' ? item.traintuple.worker : item.traintuple.dataset.worker} />
                 <PermissionsMetadata permissions={item.traintuple.permissions} />
-                <MetadataMetadata metadata={item.metadata} />
+                <MetadataMetadata metadata={item.traintuple.metadata} />
                 <BrowseRelatedMetadata>
                     <BrowseRelatedLinks item={item} />
                 </BrowseRelatedMetadata>

--- a/src/app/business/routes/model/components/detail/components/testtupleSummary.js
+++ b/src/app/business/routes/model/components/detail/components/testtupleSummary.js
@@ -12,6 +12,7 @@ import {
     MetadataWrapper,
     keyLabelClassName,
     keyValueClassName,
+    MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import CopyInput from '../../../../../common/components/detail/components/copyInput';
 import ScoreMetadata from './scoreMetadata';
@@ -47,6 +48,7 @@ const TesttupleSummary = ({testtuple, addNotification}) => (
                 tupleName="testtuple"
                 item={{testtuple}}
             />
+            <MetadataMetadata metadata={testtuple.metadata} />
         </MetadataWrapper>
 
         <CodeSample

--- a/src/app/business/routes/objective/components/detail/components/metadata.js
+++ b/src/app/business/routes/objective/components/detail/components/metadata.js
@@ -5,7 +5,7 @@ import {
     BrowseRelatedMetadata,
     MetadataInterface,
     MetadataWrapper,
-    SingleMetadata, PermissionsMetadata, OwnerMetadata,
+    SingleMetadata, PermissionsMetadata, OwnerMetadata, MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import BrowseRelatedLinks from './browseRelatedLinks';
 
@@ -15,6 +15,7 @@ const Metadata = ({item, addNotification, model}) => (
         <SingleMetadata label="Metric" value={item.metrics.name} />
         <OwnerMetadata owner={item.owner} />
         <PermissionsMetadata permissions={item.permissions} />
+        <MetadataMetadata metadata={item.metadata} />
         <BrowseRelatedMetadata>
             <BrowseRelatedLinks item={item} />
         </BrowseRelatedMetadata>

--- a/src/app/business/routes/objective/components/detail/components/metadata.js
+++ b/src/app/business/routes/objective/components/detail/components/metadata.js
@@ -5,7 +5,10 @@ import {
     BrowseRelatedMetadata,
     MetadataInterface,
     MetadataWrapper,
-    SingleMetadata, PermissionsMetadata, OwnerMetadata, MetadataMetadata,
+    SingleMetadata,
+    PermissionsMetadata,
+    OwnerMetadata,
+    MetadataMetadata,
 } from '../../../../../common/components/detail/components/metadata';
 import BrowseRelatedLinks from './browseRelatedLinks';
 


### PR DESCRIPTION
This PR aims to add assets' metadata field to the frontend.

These metadata are currently displayed as follows.
When there are metadata:
<img width="400" alt="Screenshot 2020-07-24 at 8 58 40 AM" src="https://user-images.githubusercontent.com/45589315/88367517-3cf49980-cd8c-11ea-8b35-8a2bfed66579.png">

When there are no metadata:
<img width="400" alt="Screenshot 2020-07-24 at 8 59 31 AM" src="https://user-images.githubusercontent.com/45589315/88367525-41b94d80-cd8c-11ea-98da-5f1bb05da11a.png">
