### PR TITLE
Bump lodash version

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -20,7 +20,7 @@
         "file-saver": "2.0.2",
         "history": "4.10.1",
         "keycode": "2.2.0",
-        "lodash": "4.17.15",
+        "lodash": "4.17.20",
         "mime-types": "2.1.24",
         "prop-types": "15.7.2",
         "react": "16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12171,6 +12171,11 @@ lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4, lodash@^4.0.0, lodash@^4.12.0, lod
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 lodash@^4.0.1, lodash@^4.17.12, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"


### PR DESCRIPTION
This fixes a prototype pollution issue reported by SNYK: https://snyk.io/vuln/SNYK-JS-LODASH-590103